### PR TITLE
Remove metadata before trying to compile alpha nodes

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,7 +3,10 @@ Cerner Corporation
 - Ryan Brush [@rbrush]
 - Mike Rodriguez [@mrrodriguez]
 - William Parker [@WilliamParker]
+- Ethan Christian [@EthanEChristian]
 
 [@rbrush]: https://github.com/rbrush
 [@mrrodriguez]: https://github.com/mrrodriguez
 [@WilliamParker]: https://github.com/WilliamParker
+[@EthanEChristian]: https://github.com/EthanEChristian
+

--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -1472,9 +1472,12 @@
         :let [{:keys [type constraints fact-binding args]} condition
               cmeta (meta condition)
               alpha-expr (with-meta (compile-condition
-                                     type (first args)  constraints
-                                     fact-binding env)
-                           (meta condition))]]
+                                      type (first args)  constraints
+                                      fact-binding env)
+                           ;; Remove all metadata but file and line number
+                           ;; to protect from evaluating usafe metadata
+                           ;; See PR 243 for more detailed discussion
+                           (select-keys cmeta [:line :file]))]]
 
     (with-meta
       (cond-> {:type (effective-type type)

--- a/src/test/clojure/clara/test_rules.clj
+++ b/src/test/clojure/clara/test_rules.clj
@@ -4974,3 +4974,20 @@
           (str "As long as one negation condition in the :or matches, regardless of how many facts match the other "
                "negation the rule should fire for join type " join-type)))))
 
+(deftest test-unresolvable-symbols-in-metadata-on-conditions
+  ;; Test removal of unwanted metadata; see PR 243 for details
+  (let [rule-output (atom nil)
+        ns-nom (ns-name *ns*)
+        rule {:ns-name ns-nom
+              :name (str ns-nom "/unresolvable-metadata-rule")
+              :lhs [(with-meta {:type Temperature
+                                :constraints [(list `< 'temperature 20)]}
+                      {:custom-meta 'unresolvable-symbol})]
+              :rhs `(do (reset! ~'rule-output ~'?__token__))
+              :env {:rule-output rule-output}}
+
+        session (-> (mk-session [rule])
+                    (insert (->Temperature 10 "MCI"))
+                    (fire-rules))]
+
+    (is (has-fact? @rule-output (->Temperature 10 "MCI")))))


### PR DESCRIPTION
Preserving metadata from the condition on the alpha expression doesn't seem to have much benefit and can lead to some rather odd exceptions if it contains unresolvable symbols, eg. 

the tested add, prior to the removal of the metadata, throws
```
 ERROR in (test-unresolvable-symbols-in-metadata-on-conditions) (core.clj:4593)
Uncaught exception, not in assertion.
expected: nil
  actual: clojure.lang.ExceptionInfo: Failed compiling alpha node
{:expr (clojure.core/fn [?__fact__ {:keys [rule-output]}] (clojure.core/let [this ?__fact__ temperature (.-temperature ?__fact__) ?__bindings__ (clojure.core/atom {})] (if (clojure.core/< temperature 20) (clojure.core/deref ?__bindings__) nil))), :condition {:type clara.rules.testfacts.Temperature, :constraints [(clojure.core/< temperature 20)]}, :env {:rule-output #object[clojure.lang.Atom 0x6cfcd230 {:status :ready, :val nil}]}}

 at clojure.core$ex_info.invoke (core.clj:4593)
    clara.rules.compiler$try_eval.invoke (compiler.clj:225)
    clara.rules.compiler$eval6096$compile_alpha_nodes__6097$fn__6098$iter__6099__6103$fn__6104$fn__6105$fn__6109.invoke (compiler.clj:1485)
    clara.rules.compiler$eval6096$compile_alpha_nodes__6097$fn__6098$iter__6099__6103$fn__6104$fn__6105.invoke (compiler.clj:1481)
    clara.rules.compiler$eval6096$compile_alpha...
...
...
Caused by: clojure.lang.Compiler$CompilerException: java.lang.RuntimeException: Unable to resolve symbol: unresolvable-symbol in this context, compiling:(/private/var/folders/bn/d534tk9x6qj41tvgpfkr1mysfnmmcl/T/form-init2742502976728890894.clj:1:6419)
 at clojure.lang.Compiler.analyze (Compiler.java:6543)
    clojure.lang.Compiler.analyze (Compiler.java:6485)
    clojure.lang.Compiler$MapExpr.parse (Compiler.java:3050)
    clojure.lang.Compiler$FnExpr.parse (Compiler.java:3998)
...
```

@WilliamParker @mrrodriguez 