### PR TITLE
Issue 239: Remove clojure hierarchy checks on internal facts, replace…

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,7 +3,10 @@ Cerner Corporation
 - Ryan Brush [@rbrush]
 - Mike Rodriguez [@mrrodriguez]
 - William Parker [@WilliamParker]
+- Ethan Christian [@EthanEChristian]
 
 [@rbrush]: https://github.com/rbrush
 [@mrrodriguez]: https://github.com/mrrodriguez
 [@WilliamParker]: https://github.com/WilliamParker
+[@EthanEChristian]: https://github.com/EthanEChristian
+

--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -28,7 +28,8 @@
             AccumulateWithJoinFilterNode
             LocalTransport
             LocalSession
-            Accumulator]
+            Accumulator
+            ISystemFact]
            [java.beans
             PropertyDescriptor]))
 
@@ -1508,14 +1509,14 @@
   returns a map associating alpha nodes with the facts they accept."
   [fact-type-fn ancestors-fn alpha-roots]
 
-  (let [ ;; If a customized fact-type-fn is provided,
+  (let [;; If a customized fact-type-fn is provided,
         ;; we must use a specialized grouping function
         ;; that handles internal control types that may not
         ;; follow the provided type function.
         wrapped-fact-type-fn (if (= fact-type-fn type)
                                type
                                (fn [fact]
-                                 (if (isa? (type fact) :clara.rules.engine/system-type)
+                                 (if (instance? ISystemFact fact)
                                    ;; Internal system types always use Clojure's type mechanism.
                                    (type fact)
                                    ;; All other types defer to the provided function.
@@ -1524,7 +1525,7 @@
         ;; Wrap the ancestors-fn so that we don't send internal facts such as NegationResult
         ;; to user-provided productions.  Note that this work is memoized inside fact-type->roots.
         wrapped-ancestors-fn (fn [fact-type]
-                               (if (isa? fact-type :clara.rules.engine/system-type)
+                               (if (isa? fact-type ISystemFact)
                                  ;; Exclude system types from having ancestors for now
                                  ;; since none of our use-cases require them.  If this changes
                                  ;; we may need to define a custom hierarchy for them.

--- a/src/test/clojure/clara/test_rules.clj
+++ b/src/test/clojure/clara/test_rules.clj
@@ -17,6 +17,8 @@
             [schema.test])
   (import [clara.rules.testfacts Temperature WindSpeed Cold Hot TemperatureHistory
            ColdAndWindy LousyWeather First Second Third Fourth FlexibleFields]
+          [clara.rules.engine
+           ISystemFact]
           [java.util TimeZone]
           [clara.tools.tracing
            PersistentTracingListener]))
@@ -1193,7 +1195,7 @@
         ;; the most general user-provided production possible.  See issue 149 for discussion of the issue
         ;; that caused internal facts, specifically NegationResult, to be used in these test cases.
         no-system-types? (fn [session]
-                           (not-any? (fn [fact] (isa? (type fact) ::eng/system-type))
+                           (not-any? (fn [fact] (instance? ISystemFact fact))
                                      (as-> session x
                                        (query x object-query)
                                        (map :?o x))))]


### PR DESCRIPTION
… with a marker interface

Issue #239: 

It could be done faster, if instead of the interface we went with a straight
`(indentical? (class fact) NegationResult)`
but this would be less extensible for future system facts.

Running a couple quick bench marks:

Setup
```
(require '[criterium.core :as crit])

(defprotocol ISystemFact)

(defmacro gen-record-classes
  [num-record-classes]
  (let [gen-record-symbol #(symbol (str "TestRecord" %))
        gen-record-form #(if (= 0 (mod % 50)) 
                           (list `defrecord (gen-record-symbol %) [] `ISystemFact)
                           (list `defrecord (gen-record-symbol %) []))
        gen-derived-form #(list `derive (gen-record-symbol %) ::system-type-fact)
        derived-forms (for [x (range (Math/floor (/ num-record-classes 50)))]
                        (gen-derived-form (* 50 x)))]
    `(do ~@(mapv gen-record-form (range num-record-classes))
         ~@derived-forms)))

;; TestRecords 0-99
;; TestRecord 0 and 50 ::system-type-fact
;; TestRecord 0 and 50 ISystemFact
(gen-record-classes 100)


(let [rec-symbols (mapv #(resolve (symbol (str "->TestRecord" %))) (range 100))]
          (def test-records (doall
                              (shuffle 
                                (into []
                                  (for [_ (range (/ 1E5 100))
                                        y rec-symbols]
                                    (y)))))))
```

Benchmarks
```
(crit/with-progress-reporting 
  (crit/bench (doseq [x test-records]
                (isa? (type x) ::system-type-fact))))


Evaluation count : 60 in 60 samples of 1 calls.
             Execution time mean : 1.350904 sec
    Execution time std-deviation : 37.959478 ms
   Execution time lower quantile : 1.322498 sec ( 2.5%)
   Execution time upper quantile : 1.458715 sec (97.5%)
                   Overhead used : 2.016640 ns

Found 11 outliers in 60 samples (18.3333 %)
	low-severe	 5 (8.3333 %)
	low-mild	 6 (10.0000 %)


(crit/with-progress-reporting 
  (crit/bench (doseq [x test-records]
                (instance? ISystemFact x))))

Evaluation count : 286860 in 60 samples of 4781 calls.
             Execution time mean : 207.726407 µs
    Execution time std-deviation : 4.254857 µs
   Execution time lower quantile : 203.674234 µs ( 2.5%)
   Execution time upper quantile : 213.449557 µs (97.5%)
                   Overhead used : 2.016640 ns

Found 3 outliers in 60 samples (5.0000 %)
	low-severe	 2 (3.3333 %)
	low-mild	 1 (1.6667 %)
 Variance from outliers : 9.3793 % Variance is slightly inflated by outliers
```

The instance check does quite a bit better.

@WilliamParker @mrrodriguez  