### PR TITLE
Fix malformed test and add intellij files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ pom.xml.asc
 .lein-repl-history
 figwheel_server.log
 *.*~
+.idea/*
+*.iml

--- a/src/test/clojure/clara/test_rules.clj
+++ b/src/test/clojure/clara/test_rules.clj
@@ -3627,9 +3627,9 @@
                                  (fire-rules)))
 
         run-session-untraced (fn []
-                               (mk-session [r1 r2])
-                               (insert (->First))
-                               (fire-rules))
+                               (-> (mk-session [r1 r2])
+                                   (insert (->First))
+                                   (fire-rules)))
 
         listeners-from-trace (fn [e] (mapcat :listeners
                                              (get-all-ex-data e)))]


### PR DESCRIPTION
Basically this test was passing because it was throwing an arity exception, not because of what it was testing.

Interestingly, cursive found this for me, which was neat.