### PR TITLE
Remove unnecessary to-transient call on the memory when running queri…

### DIFF
--- a/src/main/clojure/clara/rules/engine.cljc
+++ b/src/main/clojure/clara/rules/engine.cljc
@@ -1893,13 +1893,12 @@
                      get-alphas-fn
                      [])))
 
-  ;; TODO: queries shouldn't require the use of transient memory.
   (query [session query params]
     (let [query-node (get-in rulebase [:query-nodes query])]
       (when (= nil query-node)
         (platform/throw-error (str "The query " query " is invalid or not included in the rule base.")))
 
-      (->> (mem/get-tokens (mem/to-transient memory) query-node params)
+      (->> (mem/get-tokens memory query-node params)
 
            ;; Get the bindings for each token and filter generate symbols.
            (map (fn [{bindings :bindings}]


### PR DESCRIPTION
…es on a LocalSession

I don't see any reason why we need a transient memory to query and when I changed it no tests failed.  The [PersistentLocalMemory implementation](https://github.com/cerner/clara-rules/blob/0.14.0/src/main/clojure/clara/rules/memory.cljc#L930) appears consistent with the [TransientLocalMemory implementation](https://github.com/cerner/clara-rules/blob/0.14.0/src/main/clojure/clara/rules/memory.cljc#L448) While actual operations to change the tokens in the memory can change the nested data structures in the beta-memory involved to mutable ones the only impact of the initial to-transient call is to [make the beta memory a Clojure transient map](https://github.com/cerner/clara-rules/blob/0.14.0/src/main/clojure/clara/rules/memory.cljc#L984).  I don't see any reason why this should be needed for the get calls involved in retrieving the tokens as seen in the links to the get-tokens implementations above.

I'm guessing that whatever reason for this existed is no longer applicable.  @rbrush do you recall why this to-transient call was added?