### PR TITLE
Issue 280:

### DIFF
--- a/src/test/clojure/clara/tools/test_inspect.clj
+++ b/src/test/clojure/clara/tools/test_inspect.clj
@@ -402,4 +402,25 @@
                " with unused previous binding: "
                unused-previous-binding
                " and subsequent binding: "
-               subsequent-binding))))) 
+               subsequent-binding)))))
+
+(deftest test-inspect-retracted-fact
+  (let [temp-query (dsl/parse-query [] [[Temperature (= ?t temperature)]])
+        session (-> (mk-session [temp-query] :cache false)
+                    (insert (->Temperature 10 "MCI"))
+                    fire-rules
+                    (retract (->Temperature 10 "MCI"))
+                    fire-rules)
+        condition-matching-facts (-> session
+                                     inspect
+                                     :condition-matches
+                                     vals)
+
+        query-matches (-> session
+                          inspect
+                          :query-matches
+                          vals)]
+    
+    (is (every? empty? query-matches))
+    (is (every? empty? condition-matching-facts))))
+


### PR DESCRIPTION
  - In clara.tools.inspect, return empty collections of matches when no match is present for a rule, query, or condition.
    In some cases we previously returned a collection with elements that were either nil or an explanation record with nothing in it.
  - Fix memory leak where bindings from facts that are retracted were held by the memory.