### PR TITLE
Issue 186: Make the Leiningen build fail when ClojureScript tests fail

### DIFF
--- a/src/test/clojurescript/clara/test.cljs
+++ b/src/test/clojurescript/clara/test.cljs
@@ -16,21 +16,29 @@
 
 (enable-console-print!)
 
+(def ^:dynamic *successful?* nil)
+
 (defmethod cljs.test/report [:cljs.test/default :end-run-tests] [m]
   (if (cljs.test/successful? m)
-    (println "Success!")
-    (println "FAIL")))
+    (do
+      (println "Success!")
+      (reset! *successful?* true))
+    (do
+      (println "FAIL")
+      (reset! *successful?* false))))
 
 (defn ^:export run []
-  (test/run-tests 'clara.test-rules
-                  'clara.test-common
-                  'clara.test-salience
-                  'clara.test-testing-utils
-                  'clara.test-complex-negation
-                  'clara.test-accumulators
-                  'clara.test-exists
-                  'clara.tools.test-tracing
-                  'clara.test-truth-maintenance
-                  'clara.test-dsl
-                  'clara.test-accumulation
-                  'clara.test-memory))
+  (binding [*successful?* (atom nil)]
+    (test/run-tests 'clara.test-rules
+                    'clara.test-common
+                    'clara.test-salience
+                    'clara.test-testing-utils
+                    'clara.test-complex-negation
+                    'clara.test-accumulators
+                    'clara.test-exists
+                    'clara.tools.test-tracing
+                    'clara.test-truth-maintenance
+                    'clara.test-dsl
+                    'clara.test-accumulation
+                    'clara.test-memory)
+    @*successful?*))

--- a/src/test/js/runner.js
+++ b/src/test/js/runner.js
@@ -13,18 +13,25 @@ page.onConsoleMessage = function (message) {
 var url = system.args[1];
 
 page.open(url, function (status) {
-  if (status !== "success") {
-    console.log('Failed to open ' + url);
+    if (status !== "success") {
+	console.log('Failed to open ' + url);
+	setTimeout(function() {
+	    phantom.exit(1);
+	}, 0);
+    }
+
+    // Note that we have to return a primitive value from this function
+    // rather than setting a closure variable.  The executed function is sandboxed
+    // by PhantomJS and can't set variables outside its scope.
+    var success = page.evaluate(function() {
+	return clara.test.run();
+    });
+
     setTimeout(function() {
-      phantom.exit(1);
+	if (success){
+	    phantom.exit(0);
+	} else {
+	    phantom.exit(1);
+	}
     }, 0);
-  }
-
-  page.evaluate(function() {
-    clara.test.run();
-  });
-
-  setTimeout(function() {
-    phantom.exit(0);
-  }, 0);
 });


### PR DESCRIPTION
I added a commit on top of this in a branch in my fork that deliberately causes a ClojureScript-only failure.  The commit and the failed Travis CI build (I set up Travis to build my fork's branches) are visible in [that branch's history](https://github.com/WilliamParker/clara-rules/commits/issue186-cause-failure).