### PR TITLE
Fix exception in explain-activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 This is a history of changes to clara-rules.
 
+### 0.17.0-SNAPSHOT
+* Fix exception in explain-activations.
+
 ### 0.16.0
 * Eliminate laziness that broke internal contracts around order of execution, causing an exception to be thrown when executing queries with negation conditions in some edge cases.  See [issue 303](https://github.com/cerner/clara-rules/issues/303) for details.
 
@@ -107,7 +110,7 @@ Here are the specifics on what changed since 0.9.2:
 
 * Fix unification bugs when dealing with nested negations. See [issue 166](https://github.com/cerner/clara-rules/issues/166).
 * Properly handle tests nested in negation nodes. See [issue 165](https://github.com/cerner/clara-rules/issues/165).
-* Improve inspect function to explain the insertion of a given fact. See [issue 161](https://github.com/cerner/clara-rules/issues/161).  
+* Improve inspect function to explain the insertion of a given fact. See [issue 161](https://github.com/cerner/clara-rules/issues/161).
 * Remove duplicate rules and dependency on order of rules when creating sessions. See [issue 157](https://github.com/cerner/clara-rules/issues/157).
 * Significantly improve performance of building the Rete network when dealing with large disjunctions. See [issue 153](https://github.com/cerner/clara-rules/issues/153).
 * Allow multiple binding and equality checks in a single expression. See [issue 151](https://github.com/cerner/clara-rules/issues/151).

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,9 +6,13 @@ Cerner Corporation
 - Ethan Christian [@EthanEChristian]
 - Pushkar Kulkarni [@kulkarnipushkar]
 
+Community
+
+- David Goeke [@dgoeke]
+
 [@rbrush]: https://github.com/rbrush
 [@mrrodriguez]: https://github.com/mrrodriguez
 [@WilliamParker]: https://github.com/WilliamParker
 [@EthanEChristian]: https://github.com/EthanEChristian
 [@kulkarnipushkar]: https://github.com/kulkarnipushkar
-
+[@dgoeke]: https://github.com/dgoeke

--- a/src/main/clojure/clara/tools/inspect.clj
+++ b/src/main/clojure/clara/tools/inspect.clj
@@ -206,7 +206,7 @@
   "Prints a human-readable explanation of the facts and conditions that created the Rete token."
   ([explanation] (explain-activation explanation ""))
   ([explanation prefix]
-     (doseq [[fact condition] (:matches explanation)]
+     (doseq [{:keys [fact condition]} (:matches explanation)]
        (if (:from condition)
          ;; Explain why the accumulator matched.
          (let [{:keys [accumulator from]} condition]

--- a/src/test/clojure/clara/tools/test_inspect.clj
+++ b/src/test/clojure/clara/tools/test_inspect.clj
@@ -66,7 +66,7 @@
       (is (= [hot-rule-90-explanation]
              (get-in rule-dump [:rule-matches hot-rule]))
           "Rule matches test")
-      
+
       (is (= [{:explanation hot-rule-90-explanation
                :fact (map->Hot {:temperature 90})}]
              (get-in rule-dump [:insertions hot-rule]))
@@ -84,7 +84,7 @@
                                                      :rule cold-rule}]
               (map->Hot {:temperature 90}) [{:explanation hot-rule-90-explanation
                                              :rule hot-rule}]}
-             
+
              ;; Avoid dependence on the ordering of the cold explanations.
              (update (:fact->explanations rule-dump)
                      (map->Cold {:temperature :too-cold})
@@ -423,7 +423,7 @@
                           inspect
                           :query-matches
                           vals)]
-    
+
     (is (every? empty? query-matches))
     (is (every? empty? condition-matching-facts))))
 
@@ -461,7 +461,7 @@
                                             [:not [Temperature (tu/join-filter-equals temperature ?t)
                                                    (< temperature 0)]]]
                                            (insert! (->Hot :from-join)))
-        
+
         not-cold-rule (dsl/parse-rule [[:not [Temperature (< temperature 0)]]]
                                       (insert! (->Hot :unknown)))
 
@@ -535,7 +535,7 @@
                                                   {:session session
                                                    :fact-type fact-type}))
                                   (some-> matching-entries first val))))]
-    
+
     (is (= (query simple-successful-join cold-windy-query)
            (query complex-successful-join cold-windy-query)
            [{:?t 0 :?w 50}]))
@@ -553,3 +553,11 @@
            (get-condition-match simple-failed-join WindSpeed)
            (get-condition-match complex-failed-join WindSpeed)
            [(->WindSpeed 50 "MCI")]))))
+
+(deftest test-explain-activations-does-not-crash
+  (let [cold-rule (dsl/parse-rule [[Temperature (< temperature 20) (= ?t temperature)]]
+                                  (insert! (map->Cold {:temperature :too-cold})))
+        session   (-> (mk-session [cold-rule])
+                      (insert (->Temperature 15 "MCI"))
+                      (fire-rules))]
+   (is (with-out-str (explain-activations session)))))


### PR DESCRIPTION
Previously, when iterating over a list of matches, each match
was assumed to be a vector of `[fact condition]` but was actually
a map of `{:fact ... :condition ...}`. Destructuring the map into
a vector threw an UnsupportedOperationException.