### PR TITLE
Add constraint to parser for empty :test conditions

### DIFF
--- a/src/main/clojure/clara/rules/dsl.clj
+++ b/src/main/clojure/clara/rules/dsl.clj
@@ -136,7 +136,7 @@
 
    (contains? #{'test :test} (first expression))
    (if (= 1 (count expression))
-     (throw-dsl-ex (str "Empty test conditions are not allowed.")
+     (throw-dsl-ex (str "Empty :test conditions are not allowed.")
                    {}
                    expr-meta)
      {:constraints (vec (rest expression))})

--- a/src/main/clojure/clara/rules/dsl.clj
+++ b/src/main/clojure/clara/rules/dsl.clj
@@ -135,7 +135,12 @@
            (parse-expression nested-expr expr-meta)))
 
    (contains? #{'test :test} (first expression))
-   {:constraints (vec (rest expression))}
+   (if (= 1 (count expression))
+     (throw-dsl-ex (str "Empty test conditions are not allowed.")
+                   {}
+                   expr-meta)
+     {:constraints (vec (rest expression))})
+
 
    :default
    (parse-condition-or-accum expression expr-meta)))

--- a/src/test/clojure/clara/test_rules.clj
+++ b/src/test/clojure/clara/test_rules.clj
@@ -1134,15 +1134,14 @@
                (query not-different-temps))))))
 
 (deftest test-empty-test-condition
-
-  (is (thrown-with-msg?
-        clojure.lang.ExceptionInfo
-        #"line.*123.*column.*456"
-        (dsl/parse-query*
-          []
-          [[:test]]
-          {}
-          {:line 123 :column 456}))))
+  (let [exception-data {:line 123 :column 456}]
+    (is (assert-ex-data
+          exception-data
+          (dsl/parse-query*
+            []
+            [[:test]]
+            {}
+            exception-data)))))
 
 (deftest test-multi-insert-retract
 

--- a/src/test/clojure/clara/test_rules.clj
+++ b/src/test/clojure/clara/test_rules.clj
@@ -1133,6 +1133,17 @@
                fire-rules
                (query not-different-temps))))))
 
+(deftest test-empty-test-condition
+
+  (is (thrown-with-msg?
+        clojure.lang.ExceptionInfo
+        #"line.*123.*column.*456"
+        (dsl/parse-query*
+          []
+          [[:test]]
+          {}
+          {:line 123 :column 456}))))
+
 (deftest test-multi-insert-retract
 
   (is (= #{{:?loc "MCI"} {:?loc "BOS"}}

--- a/src/test/common/clara/test_dsl.cljc
+++ b/src/test/common/clara/test_dsl.cljc
@@ -299,25 +299,25 @@
 #?(:clj
    (def-rules-test test-rhs-locals-shadowing-vars
 
-     {:rules [r1 [[[:test]]
+     {:rules [r1 [[]
                   (let [{:keys [locals-shadowing-tester]} {:locals-shadowing-tester :good}]
                     (insert! ^{:type :result}
                              {:r :r1
                               :v locals-shadowing-tester}))]
 
-              r2 [[[:test]]
+              r2 [[]
                   (let [locals-shadowing-tester :good]
                     (insert! ^{:type :result}
                              {:r :r2
                               :v locals-shadowing-tester}))]
 
-              r3 [[[:test]]
+              r3 [[]
                   (let [[locals-shadowing-tester] [:good]]
                     (insert! ^{:type :result}
                              {:r :r3
                               :v locals-shadowing-tester}))]
 
-              r4 [[[:test]]
+              r4 [[]
                   (insert-all! (for [_ (range 1)
                                      :let [locals-shadowing-tester :good]]
                                  ^{:type :result}
@@ -337,7 +337,6 @@
                           {:r :r4
                            :v :good}])
             (->> (-> empty-session
-                     (insert ^{:type :test} {})
                      fire-rules
                      (query q))
                  (map :?r)

--- a/src/test/common/clara/test_dsl.cljc
+++ b/src/test/common/clara/test_dsl.cljc
@@ -299,25 +299,25 @@
 #?(:clj
    (def-rules-test test-rhs-locals-shadowing-vars
 
-     {:rules [r1 [[]
+     {:rules [r1 [[[Temperature]]
                   (let [{:keys [locals-shadowing-tester]} {:locals-shadowing-tester :good}]
                     (insert! ^{:type :result}
                              {:r :r1
                               :v locals-shadowing-tester}))]
 
-              r2 [[]
+              r2 [[[Temperature]]
                   (let [locals-shadowing-tester :good]
                     (insert! ^{:type :result}
                              {:r :r2
                               :v locals-shadowing-tester}))]
 
-              r3 [[]
+              r3 [[[Temperature]]
                   (let [[locals-shadowing-tester] [:good]]
                     (insert! ^{:type :result}
                              {:r :r3
                               :v locals-shadowing-tester}))]
 
-              r4 [[]
+              r4 [[[Temperature]]
                   (insert-all! (for [_ (range 1)
                                      :let [locals-shadowing-tester :good]]
                                  ^{:type :result}
@@ -337,6 +337,7 @@
                           {:r :r4
                            :v :good}])
             (->> (-> empty-session
+                     (insert (->Temperature 10 "MCI"))
                      fire-rules
                      (query q))
                  (map :?r)


### PR DESCRIPTION
- Previously an empty test condition (aka [:test]) was valid to the
  parse and would generate pointless beta nodes. This change throws an
  exception when parsing that.

This is something we noticed when doing an internal code review for something else and it seemed like an easy enough fix. I can't think of a situation in which we would want an empty test condition. Additionally, it looks like the parser would have intercepted it had`[:test]` been intended as a type anyway, so i dont think this changes anything functionally there. 