### PR TITLE
Refactor tests of RHS retraction to be cross-platform(clj/cljs)

### DIFF
--- a/src/test/clojure/clara/test_rules.clj
+++ b/src/test/clojure/clara/test_rules.clj
@@ -1194,27 +1194,6 @@
            (set
             (query session sample/find-cold-and-windy))))))
 
-(deftest test-retract!
-  (let [not-cold-rule (dsl/parse-rule [[Temperature (> temperature 50)]]
-                               (retract! (->Cold 20)))
-
-        cold-query (dsl/parse-query [] [[Cold (= ?t temperature)]])
-
-        session (-> (mk-session [not-cold-rule cold-query])
-                    (insert (->Cold 20))
-                    (fire-rules))]
-
-    ;; The session should contain our initial cold reading.
-    (is (= #{{:?t 20}}
-           (set (query session cold-query))))
-
-    ;; Insert a higher temperature and ensure the cold fact was retracted.
-    (is (= #{}
-           (set (query (-> session
-                           (insert (->Temperature 80 "MCI"))
-                           (fire-rules))
-                       cold-query))))))
-
 (deftest test-no-loop
   (let [reduce-temp (dsl/parse-rule [[?t <- Temperature (> temperature 0) (= ?v temperature)]]
                              (do

--- a/src/test/clojurescript/clara/test.cljs
+++ b/src/test/clojurescript/clara/test.cljs
@@ -13,7 +13,8 @@
             [clara.test-dsl]
             [clara.test-accumulation]
             [clara.test-memory]
-            [clara.test-simple-rules]))
+            [clara.test-simple-rules]
+            [clara.test-rhs-retract]))
 
 (enable-console-print!)
 
@@ -42,5 +43,6 @@
                     'clara.test-dsl
                     'clara.test-accumulation
                     'clara.test-memory
-                    'clara.test-simple-rules)
+                    'clara.test-simple-rules
+                    'clara.test-rhs-retract)
     @*successful?*))

--- a/src/test/common/clara/test_rhs_retract.cljc
+++ b/src/test/common/clara/test_rhs_retract.cljc
@@ -1,0 +1,62 @@
+#?(:clj
+   (ns clara.test-rhs-retract
+     (:require [clara.tools.testing-utils :refer [def-rules-test] :as tu]
+               [clara.rules :refer [fire-rules
+                                    insert
+                                    insert-all
+                                    insert!
+                                    retract
+                                    query
+                                    retract!]]
+
+               [clara.rules.testfacts :refer [->Temperature ->Cold]]
+               [clojure.test :refer [is deftest run-tests testing use-fixtures]]
+               [clara.rules.accumulators]
+               [schema.test :as st])
+     (:import [clara.rules.testfacts
+               Temperature
+               Cold]))
+
+   :cljs
+   (ns clara.test-rhs-retract
+     (:require [clara.rules :refer [fire-rules
+                                    insert
+                                    insert!
+                                    insert-all
+                                    retract
+                                    query
+                                    retract!]]
+               [clara.rules.testfacts :refer [->Temperature Temperature
+                                              ->Cold Cold]]
+               [clara.rules.accumulators]
+               [cljs.test]
+               [schema.test :as st])
+     (:require-macros [clara.tools.testing-utils :refer [def-rules-test]]
+                      [cljs.test :refer [is deftest run-tests testing use-fixtures]])))
+
+(use-fixtures :once st/validate-schemas #?(:clj tu/opts-fixture))
+
+(def-rules-test test-retract!
+
+  {:rules [not-cold-rule [[[Temperature (> temperature 50)]]
+                          (retract! (->Cold 20))]]
+
+   :queries [cold-query [[]
+                         [[Cold (= ?t temperature)]]]]
+
+   :sessions [empty-session [not-cold-rule cold-query] {}]}
+
+  (let [session (-> empty-session
+                    (insert (->Cold 20))
+                    (fire-rules))]
+    
+    ;; The session should contain our initial cold reading.
+    (is (= #{{:?t 20}}
+           (set (query session cold-query))))
+
+    ;; Insert a higher temperature and ensure the cold fact was retracted.
+    (is (= #{}
+           (set (query (-> session
+                           (insert (->Temperature 80 "MCI"))
+                           (fire-rules))
+                       cold-query))))))


### PR DESCRIPTION
I realize this isn't a long new test file, but RHS(right-hand-side) retraction is a very logically distinctive operation and we will likely want to have additional tests of RHS retraction in the future, so I think it makes sense to add a separate test namespace for it.  Like similar PRs, this also has the benefit of testing both Clojure and ClojureScript while our existing tests that this ports test only Clojure.

Given that this is such a small change and a test-only one I plan to merge this tomorrow unless there are objections.