### PR TITLE
Don't override Clojure 1.9's `qualified-keyword?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 This is a history of changes to clara-rules.
 
+### 0.19.0-SNAPSHOT
+* Remove a warning about `qualified-keyword?` being replaced when using Clojure 1.9.
+
 ### 0.18.0
 * Remove unnecessary memory operations from ProductionNode to optimize performance.  Remove :rule-matches in session inspection that did not cause logical insertions and add a new optional feature to return all rule matches, regardless of what their RHS did or whether they were retracted. Add a new listener and tracing method fire-activation!. These changes are moderately non-passive with respect to listening, tracing, and session inspection but are otherwise passive.  See [issue 386](https://github.com/cerner/clara-rules/issues/386) for details.
 * Support keyword names for use in custom DSLs. See [issue 371](https://github.com/cerner/clara-rules/issues/371) for details.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,6 +10,7 @@ Community
 
 - David Goeke [@dgoeke]
 - Dave Dixon [@sparkofreason]
+- Baptiste Fontaine [@bfontaine]
 
 [@rbrush]: https://github.com/rbrush
 [@mrrodriguez]: https://github.com/mrrodriguez
@@ -18,3 +19,4 @@ Community
 [@kulkarnipushkar]: https://github.com/kulkarnipushkar
 [@dgoeke]: https://github.com/dgoeke
 [@sparkofreason]: https://github.com/sparkofreason
+[@bfontaine]: https://github.com/bfontaine

--- a/src/main/clojure/clara/rules/dsl.clj
+++ b/src/main/clojure/clara/rules/dsl.clj
@@ -8,7 +8,8 @@
             [clara.rules.engine :as eng]
             [clara.rules.compiler :as com]
             [clara.rules.schema :as schema]
-            [schema.core :as sc]))
+            [schema.core :as sc])
+  (:refer-clojure :exclude [qualified-keyword?]))
 
 ;; Let operators be symbols or keywords.
 (def ops #{'and 'or 'not 'exists :and :or :not :exists})


### PR DESCRIPTION
When using Clojure 1.9 and Clara Rules 0.18.0, requiring `clara.rules.dsl` or any namespace that requires it results in the following warning:

    WARNING: qualified-keyword? already refers to: #'clojure.core/qualified-keyword? in namespace: clara.rules.dsl, being replaced by: #'clara.rules.dsl/qualified-keyword?

This change removes the inclusion of Clojure 1.9’s `qualified-keyword?` from this namespace, and thus the warning.