### PR TITLE
Issue #381 Reduce the number of Eval calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ This is a history of changes to clara-rules.
 
 ### 0.19.0-SNAPSHOT
 * Remove a warning about `qualified-keyword?` being replaced when using Clojure 1.9.
+* Batch evaluation of node expressions for better compilation performance. See [issue 381](https://github.com/cerner/clara-rules/issues/381)
 
 ### 0.18.0
 * Remove unnecessary memory operations from ProductionNode to optimize performance.  Remove :rule-matches in session inspection that did not cause logical insertions and add a new optional feature to return all rule matches, regardless of what their RHS did or whether they were retracted. Add a new listener and tracing method fire-activation!. These changes are moderately non-passive with respect to listening, tracing, and session inspection but are otherwise passive.  See [issue 386](https://github.com/cerner/clara-rules/issues/386) for details.

--- a/project.clj
+++ b/project.clj
@@ -68,8 +68,15 @@
   ;; perhaps because Leiningen is using this as uneval'ed code.
   ;; For now just duplicate the line.
   :test-selectors {:default (complement (fn [x]
-                                          (some->> x :ns ns-name str (re-matches #"^clara\.generative.*"))))
-                   :generative (fn [x] (some->> x :ns ns-name str (re-matches #"^clara\.generative.*")))}
+                                          (let [backlisted-packages #{"generative" "performance"}
+                                                patterns (into []
+                                                           (comp
+                                                             (map #(str "^clara\\." % ".*"))
+                                                             (interpose "|"))
+                                                           backlisted-packages)]
+                                            (some->> x :ns ns-name str (re-matches (re-pattern (apply str patterns)))))))
+                   :generative (fn [x] (some->> x :ns ns-name str (re-matches #"^clara\.generative.*")))
+                   :performance (fn [x] (some->> x :ns ns-name str (re-matches #"^clara\.performance.*")))}
   
   :scm {:name "git"
         :url "https://github.com/cerner/clara-rules"}

--- a/project.clj
+++ b/project.clj
@@ -68,12 +68,12 @@
   ;; perhaps because Leiningen is using this as uneval'ed code.
   ;; For now just duplicate the line.
   :test-selectors {:default (complement (fn [x]
-                                          (let [backlisted-packages #{"generative" "performance"}
+                                          (let [blacklisted-packages #{"generative" "performance"}
                                                 patterns (into []
                                                            (comp
                                                              (map #(str "^clara\\." % ".*"))
                                                              (interpose "|"))
-                                                           backlisted-packages)]
+                                                           blacklisted-packages)]
                                             (some->> x :ns ns-name str (re-matches (re-pattern (apply str patterns)))))))
                    :generative (fn [x] (some->> x :ns ns-name str (re-matches #"^clara\.generative.*")))
                    :performance (fn [x] (some->> x :ns ns-name str (re-matches #"^clara\.performance.*")))}

--- a/src/main/clojure/clara/rules.cljc
+++ b/src/main/clojure/clara/rules.cljc
@@ -330,8 +330,8 @@
       * :activation-group-sort-fn, a comparator function used to sort the values returned by the above :activation-group-fn.
         Defaults to >, so rules with a higher salience are executed first.
       * :forms-per-eval - The maximum number of expressions that will be evaluated per call to eval.
-        Larger batch sizes should see better performance compared to smaller batch sizes.
-        Defaults to 1250.
+        Larger batch sizes should see better performance compared to smaller batch sizes. (Only applicable to Clojure)
+        Defaults to 5000, see clara.rules.compiler/forms-per-eval-default for more information.
 
       This is not supported in ClojureScript, since it requires eval to dynamically build a session. ClojureScript
       users must use pre-defined rule sessions using defsession."

--- a/src/main/clojure/clara/rules.cljc
+++ b/src/main/clojure/clara/rules.cljc
@@ -329,7 +329,7 @@
         It defaults to checking the :salience property, or 0 if none exists.
       * :activation-group-sort-fn, a comparator function used to sort the values returned by the above :activation-group-fn.
         Defaults to >, so rules with a higher salience are executed first.
-      * :compilation-partition-size - The maximum number of expressions that will be evaluated per call to eval.
+      * :forms-per-eval - The maximum number of expressions that will be evaluated per call to eval.
         Larger batch sizes should see better performance compared to smaller batch sizes.
         Defaults to 1250.
 

--- a/src/main/clojure/clara/rules.cljc
+++ b/src/main/clojure/clara/rules.cljc
@@ -210,9 +210,9 @@
                                   [(:id node) node]))
 
             ;; type, alpha node tuples.
-            alpha-nodes (for [{:keys [type alpha-fn children env]} alpha-fns
+            alpha-nodes (for [{:keys [id type alpha-fn children env]} alpha-fns
                               :let [beta-children (map id-to-node children)]]
-                          [type (eng/->AlphaNode env beta-children alpha-fn)])
+                          [type (eng/->AlphaNode id env beta-children alpha-fn)])
 
             ;; Merge the alpha nodes into a multi-map
             alpha-map (reduce

--- a/src/main/clojure/clara/rules.cljc
+++ b/src/main/clojure/clara/rules.cljc
@@ -329,6 +329,9 @@
         It defaults to checking the :salience property, or 0 if none exists.
       * :activation-group-sort-fn, a comparator function used to sort the values returned by the above :activation-group-fn.
         Defaults to >, so rules with a higher salience are executed first.
+      * :compilation-partition-size - The maximum number of expressions that will be evaluated per call to eval.
+        Larger batch sizes should see better performance compared to smaller batch sizes.
+        Defaults to 1250.
 
       This is not supported in ClojureScript, since it requires eval to dynamically build a session. ClojureScript
       users must use pre-defined rule sessions using defsession."

--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -1393,7 +1393,7 @@
   "Takes a map in form produced by extract-exprs and evaluates the values(expressions) of the map in a batched manner.
    This allows the eval calls to be more effecient, rather than evaluating each expression on its own."
   [key->expr :- {(schema/tuple sc/Int sc/Keyword) schema/SExpr}
-   partiton-size :- sc/Int]
+   partition-size :- sc/Int]
   (let [batching-try-eval (fn [node-keys exprs]
                             ;; Try to evaluate all of the expressions as a batch. If they fail the batch eval then we
                             ;; try them one by one with their compilation context, this is slow but we were going to fail
@@ -1422,7 +1422,7 @@
           (for [[ns pairs] (group-by (comp :ns meta key) key->expr)
                 ;; Partitioning the number of forms to be evaluated, Java has a limit to the size of methods if we were
                 ;; evaluate all expressions at once it would likely exceed this limit and throw an exception.
-                pairs (partition-all partiton-size pairs)
+                pairs (partition-all partition-size pairs)
                 :let [node-keys (map #(nth % 0) pairs)]]
             (mapv (fn [node-key expr]
                     [node-key expr])
@@ -1872,6 +1872,9 @@
         id-counter (atom 0)
         create-id-fn (fn [] (swap! id-counter inc))
 
+        ;; 1250 is an arbitrary number, this could be lower or higher depending on the
+        ;; rulebase that is being compiled, with regards to the average size of the
+        ;; forms being evaluated.
         compilation-partition-size (:compilation-partition-size options 1250)
 
         beta-graph (to-beta-graph productions create-id-fn)

--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -1404,6 +1404,8 @@
                             (try
                               (eval exprs)
                               (catch Exception e
+                                ;; Using mapv here rather than map to avoid laziness, otherwise compilation failure might
+                                ;; fall into the throw below for the wrong reason.
                                 (mapv (fn [expr node-keys]
                                         (let [cmeta (meta node-keys)]
                                           (with-bindings

--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -31,7 +31,9 @@
             Accumulator
             ISystemFact]
            [java.beans
-            PropertyDescriptor]))
+            PropertyDescriptor]
+           [clojure.lang
+            IFn]))
 
 ;; Protocol for loading rules from some arbitrary source.
 (defprotocol IRuleSource
@@ -71,7 +73,9 @@
                         ;; Function that takes a rule and returns its activation group.
                         activation-group-fn
                         ;; Function that takes facts and determines what alpha nodes they match.
-                        get-alphas-fn])
+                        get-alphas-fn
+                        ;; A map of [node-id field-name] to function.
+                        node-identifier-to-fn])
 
 (defn- is-variable?
   "Returns true if the given expression is a variable (a symbol prefixed by ?)"
@@ -1242,19 +1246,191 @@
 
 
 (sc/defn to-beta-graph :- schema/BetaGraph
-
   "Produces a description of the beta network."
-  [productions :- #{schema/Production}]
-
-  (let [id-counter (atom 0)
-        create-id-fn (fn [] (swap! id-counter inc))]
-
-    (reduce (fn [beta-graph production]
+  [productions :- #{schema/Production}
+   create-id-fn :- IFn]
+  (reduce (fn [beta-graph production]
               (binding [*compile-ctx* {:production production}]
                 (add-production production beta-graph create-id-fn)))
 
             empty-beta-graph
-            productions)))
+            productions))
+
+(sc/defn extract-exprs :- {(schema/tuple sc/Int sc/Keyword) schema/SExpr}
+  "Walks the Alpha and Beta graphs and extracts the expressions that will be used in the construction of the final network.
+   The extracted expressions are stored by their key, [<node-id> <field-key>], this allows for the function to be retrieved
+   after it has been compiled.
+
+   Note: The keys of the map returned carry the metadata that can be used during evaluation. This metadata will contain,
+   if available, the compile context, file and ns. This metadata is not stored on the expression itself because it will
+   contain forms that will fail to eval."
+  [beta-graph :- schema/BetaGraph
+   alpha-graph :- [schema/AlphaNode]]
+  (let [backward-edges (:backward-edges beta-graph)
+        handle-expr (fn [exprs s-expr id expr-key metadata]
+                      (assoc exprs
+                        ;; Letting the key carry all of the metadata, this makes the batch evaluation of the expressions
+                        ;; easier because the metadata contains unevalable forms.
+                        (with-meta [id expr-key] (assoc metadata expr-key s-expr))
+                        s-expr))
+        is-root? #(= #{0} (get backward-edges %))
+
+        ;; If extract-exprs ever became a hot spot, this could be changed out to use more java interop.
+        alpha-exprs (reduce (fn [prev alpha-node]
+                              (let [{:keys [id condition env]} alpha-node
+                                    {:keys [type constraints fact-binding args]} condition
+                                    cmeta (meta condition)]
+                                (handle-expr prev
+                                             (with-meta (compile-condition
+                                                          type (first args) constraints
+                                                          fact-binding env)
+                                                        ;; Remove all metadata but file and line number
+                                                        ;; to protect from evaluating usafe metadata
+                                                        ;; See PR 243 for more detailed discussion
+                                                        (select-keys cmeta [:line :file]))
+                                             id
+                                             :alpha-expr
+                                             {:file (or (:file cmeta) *file*)
+                                              :compile-ctx {:condition condition
+                                                            :env env
+                                                            :msg "compiling alpha node"}})))
+                            {}
+                            alpha-graph)
+        exprs (reduce-kv (fn [prev id production-node]
+                             (let [production (-> production-node :production)]
+                               (handle-expr prev
+                                            (with-meta (compile-action (:bindings production-node)
+                                                                       (:rhs production)
+                                                                       (:env production))
+                                                       (meta (:rhs production)))
+                                            id
+                                            :action-expr
+                                            ;; ProductionNode expressions can be arbitrary code, therefore we need the
+                                            ;; ns where the production was define so that we can compile the expression
+                                            ;; later.
+                                            {:ns (some-> (:ns-name production) str)
+                                             :file (-> production :rhs meta :file)
+                                             :compile-ctx {:production production
+                                                           :msg "compiling production node"}})))
+                           alpha-exprs
+                           (:id-to-production-node beta-graph))]
+    (reduce-kv
+      (fn [prev id beta-node]
+        (let [condition (:condition beta-node)
+              condition (if (symbol? condition)
+                          (.loadClass (clojure.lang.RT/makeClassLoader) (name condition))
+                          condition)]
+          (case (or (:node-type beta-node)
+                    ;; If there is no :node-type then the node is the ::root-condition
+                    ;; however, creating a case for nil could potentially casue weird effects if something about the
+                    ;; compilation of the beta graph changes. Therefore making an explicit case for ::root-condition
+                    ;; and if there was anything that wasn't ::root-condition this case statement will fail rather than
+                    ;; failing somewhere else.
+                    beta-node)
+            ::root-condition prev
+
+            :join (if (or (is-root? id)
+                          (not (:join-filter-expressions beta-node)))
+                    ;; This is either a RootJoin or HashJoin node, in either case they do not have an expression
+                    ;; to capture.
+                    prev
+                    (handle-expr prev
+                                 (compile-join-filter (:join-filter-expressions beta-node)
+                                                      (:join-filter-join-bindings beta-node)
+                                                      (:new-bindings beta-node)
+                                                      (:env beta-node))
+                                 id
+                                 :join-filter-expr
+                                 {:compile-ctx {:condition condition
+                                                :join-filter-expressions (:join-filter-expressions beta-node)
+                                                :env (:env beta-node)
+                                                :msg "compiling expression join node"}}))
+            :negation (if (:join-filter-expressions beta-node)
+                        (handle-expr prev
+                                     (compile-join-filter (:join-filter-expressions beta-node)
+                                                          (:join-filter-join-bindings beta-node)
+                                                          (:new-bindings beta-node)
+                                                          (:env beta-node))
+                                     id
+                                     :join-filter-expr
+                                     {:compile-ctx {:condition condition
+                                                    :join-filter-expressions (:join-filter-expressions beta-node)
+                                                    :env (:env beta-node)
+                                                    :msg "compiling negation with join filter node"}})
+                        prev)
+            :test (handle-expr prev
+                               (compile-test (:constraints condition))
+                               id
+                               :test-expr
+                               {:compile-ctx {:condition condition
+                                              :env (:env beta-node)
+                                              :msg "compiling test node"}})
+            :accumulator (cond-> (handle-expr prev
+                                              (compile-accum (:accumulator beta-node) (:env beta-node))
+                                              id
+                                              :accum-expr
+                                              {:compile-ctx {:condition condition
+                                                             :accumulator (:accumulator beta-node)
+                                                             :env (:env beta-node)
+                                                             :msg "compiling accumulator"}})
+
+                                 (:join-filter-expressions beta-node)
+                                 (handle-expr (compile-join-filter (:join-filter-expressions beta-node)
+                                                                   (:join-filter-join-bindings beta-node)
+                                                                   (:new-bindings beta-node)
+                                                                   (:env beta-node))
+                                              id
+                                              :join-filter-expr
+                                              {:compile-ctx {:condition condition
+                                                             :join-filter-expressions (:join-filter-expressions beta-node)
+                                                             :env (:env beta-node)
+                                                             :msg "compiling accumulate with join filter node"}}))
+            :query prev)))
+      exprs
+      (:id-to-condition-node beta-graph))))
+
+(sc/defn compile-exprs :- {(schema/tuple sc/Int sc/Keyword) IFn}
+  "Takes a map in form produced by extract-exprs and evaluates the values(expressions) of the map in a batched manner.
+   This allows the eval calls to be more effecient, rather than evaluating each expression on its own."
+  [key->expr :- {(schema/tuple sc/Int sc/Keyword) schema/SExpr}
+   partiton-size :- sc/Int]
+  (let [batching-try-eval (fn [node-keys exprs]
+                            ;; Try to evaluate all of the expressions as a batch. If they fail the batch eval then we
+                            ;; try them one by one with their compilation context, this is slow but we were going to fail
+                            ;; anyway.
+                            (try
+                              (eval exprs)
+                              (catch Exception e
+                                (mapv (fn [expr node-keys]
+                                        (let [cmeta (meta node-keys)]
+                                          (with-bindings
+                                            {#'*compile-ctx* (:compile-ctx cmeta)
+                                             #'*file* (:file cmeta *file*)}
+                                            (try-eval expr))))
+                                      exprs
+                                      node-keys)
+                                ;; If none of the rules are the issue, it is likely that the
+                                ;; size of the code trying to be evaluated has exceeded the limit
+                                ;; set by java.
+                                (throw (ex-info "The batching size of expressions has exceeded the limit set by java."
+                                                {:orginal-exception e})))))]
+    (into {}
+          cat
+          ;; Grouping by ns, most expressions will not have a defined ns, only expressions from production nodes.
+          ;; These expressions must be evaluated in the ns where they were defined, as they will likely contain code
+          ;; that is namespace dependent.
+          (for [[ns pairs] (group-by (comp :ns meta key) key->expr)
+                ;; Partitioning the number of forms to be evaluated, Java has a limit to the size of methods if we were
+                ;; evaluate all expressions at once it would likely exceed this limit and throw an exception.
+                pairs (partition-all partiton-size pairs)
+                :let [node-keys (map #(nth % 0) pairs)]]
+            (mapv (fn [node-key expr]
+                    [node-key expr])
+                  node-keys
+                  (with-bindings (if ns
+                                   {#'*ns* (-> ns symbol the-ns)}
+                                   {})
+                    (batching-try-eval node-keys (mapv #(nth % 1) pairs))))))))
 
 (sc/defn ^:private compile-node
   "Compiles a given node description into a node usable in the network with the
@@ -1263,14 +1439,16 @@
    id :- sc/Int
    is-root :- sc/Bool
    children :- [sc/Any]
-   compile-expr ; Function to do the evaluation.
+   id-key->expr :- {(schema/tuple sc/Int sc/Keyword) IFn}
    new-bindings :- #{sc/Keyword}]
 
   (let [{:keys [condition production query join-bindings]} beta-node
 
         condition (if (symbol? condition)
                     (.loadClass (clojure.lang.RT/makeClassLoader) (name condition))
-                    condition)]
+                    condition)
+
+        retrieve-fn (fn [id field] (get id-key->expr [id field]))]
 
     (case (:node-type beta-node)
 
@@ -1278,90 +1456,53 @@
       ;; Use an specialized root node for efficiency in this case.
       (if is-root
         (eng/->RootJoinNode
-         id
-         condition
-         children
-         join-bindings)
+          id
+          condition
+          children
+          join-bindings)
 
         ;; If the join operation includes arbitrary expressions
         ;; that can't expressed as a hash join, we must use the expressions
         (if (:join-filter-expressions beta-node)
-          (let [join-filter-expr (compile-join-filter (:join-filter-expressions beta-node)
-                                                      (:join-filter-join-bindings beta-node)
-                                                      (:new-bindings beta-node)
-                                                      (:env beta-node))]
-            (with-meta
-              (eng/->ExpressionJoinNode
-               id
-               condition
-               (binding [*compile-ctx* {:condition condition
-                                        :join-filter-expressions (:join-filter-expressions beta-node)
-                                        :env (:env beta-node)
-                                        :msg "compiling expression join node"}]
-                 (compile-expr id
-                               join-filter-expr))
-               children
-               join-bindings)
-              {:join-filter-expr join-filter-expr}))
+          (eng/->ExpressionJoinNode
+            id
+            condition
+            (retrieve-fn id :join-filter-expr)
+            children
+            join-bindings)
           (eng/->HashJoinNode
-           id
-           condition
-           children
-           join-bindings)))
+            id
+            condition
+            children
+            join-bindings)))
 
       :negation
       ;; Check to see if the negation includes an
       ;; expression that must be joined to the incoming token
       ;; and use the appropriate node type.
       (if (:join-filter-expressions beta-node)
-
-        (let [join-filter-expr (compile-join-filter (:join-filter-expressions beta-node)
-                                                    (:join-filter-join-bindings beta-node)
-                                                    (:new-bindings beta-node)
-                                                    (:env beta-node))]
-          (with-meta
-            (eng/->NegationWithJoinFilterNode
-             id
-             condition
-             (binding [*compile-ctx* {:condition condition
-                                      :join-filter-expressions (:join-filter-expressions beta-node)
-                                      :env (:env beta-node)
-                                      :msg "compiling negation with join filter node"}]
-               (compile-expr id
-                             join-filter-expr))
-             children
-             join-bindings)
-            {:join-filter-expr join-filter-expr}))
-
+        (eng/->NegationWithJoinFilterNode
+          id
+          condition
+          (retrieve-fn id :join-filter-expr)
+          children
+          join-bindings)
         (eng/->NegationNode
-         id
-         condition
-         children
-         join-bindings))
+          id
+          condition
+          children
+          join-bindings))
 
       :test
-      (let [test-expr (compile-test (:constraints condition))]
-        (with-meta
-          (eng/->TestNode
-           id
-           (binding [*compile-ctx* {:condition condition
-                                    :env (:env beta-node)
-                                    :msg "compiling test node"}]
-             (compile-expr id
-                           test-expr))
-           children)
-          {:test-expr test-expr}))
+      (eng/->TestNode
+        id
+        (retrieve-fn id :test-expr)
+        children)
 
       :accumulator
       ;; We create an accumulator that accepts the environment for the beta node
       ;; into its context, hence the function with the given environment.
-      (let [accum-expr (compile-accum (:accumulator beta-node) (:env beta-node))
-            compiled-node (binding [*compile-ctx* {:condition condition
-                                                   :accumulator (:accumulator beta-node)
-                                                   :env (:env beta-node)
-                                                   :msg "compiling accumulator"}]
-                            (compile-expr id
-                                          accum-expr))
+      (let [compiled-node (retrieve-fn id :accum-expr)
             compiled-accum (compiled-node (:env beta-node))]
 
         ;; Ensure the compiled accumulator has the expected structure
@@ -1372,83 +1513,51 @@
         ;; the specialized accumulate node.
 
         (if (:join-filter-expressions beta-node)
-
-          (let [join-filter-expr (compile-join-filter (:join-filter-expressions beta-node)
-                                                      (:join-filter-join-bindings beta-node)
-                                                      (:new-bindings beta-node)
-                                                      (:env beta-node))]
-            (with-meta
-              (eng/->AccumulateWithJoinFilterNode
-               id
-               ;; Create an accumulator structure for use when examining the node or the tokens
-               ;; it produces.
-               {:accumulator (:accumulator beta-node)
-                ;; Include the original filter expressions in the constraints for inspection tooling.
-                :from (update-in condition [:constraints]
-                                 into (-> beta-node :join-filter-expressions :constraints))}
-               compiled-accum
-               (binding [*compile-ctx* {:condition condition
-                                        :join-filter-expressions (:join-filter-expressions beta-node)
-                                        :env (:env beta-node)
-                                        :msg "compiling accumulate with join filter node"}]
-                 (compile-expr id
-                               join-filter-expr))
-               (:result-binding beta-node)
-               children
-               join-bindings
-               (:new-bindings beta-node))
-              {:accum-expr accum-expr
-               :join-filter-expr join-filter-expr}))
+          (eng/->AccumulateWithJoinFilterNode
+            id
+            ;; Create an accumulator structure for use when examining the node or the tokens
+            ;; it produces.
+            {:accumulator (:accumulator beta-node)
+             ;; Include the original filter expressions in the constraints for inspection tooling.
+             :from (update-in condition [:constraints]
+                              into (-> beta-node :join-filter-expressions :constraints))}
+            compiled-accum
+            (retrieve-fn id :join-filter-expr)
+            (:result-binding beta-node)
+            children
+            join-bindings
+            (:new-bindings beta-node))
 
           ;; All unification is based on equality, so just use the simple accumulate node.
-          (with-meta
-            (eng/->AccumulateNode
-             id
-             ;; Create an accumulator structure for use when examining the node or the tokens
-             ;; it produces.
-             {:accumulator (:accumulator beta-node)
-              :from condition}
-             compiled-accum
-             (:result-binding beta-node)
-             children
-             join-bindings
-             (:new-bindings beta-node))
-            {:accum-expr accum-expr})))
+          (eng/->AccumulateNode
+            id
+            ;; Create an accumulator structure for use when examining the node or the tokens
+            ;; it produces.
+            {:accumulator (:accumulator beta-node)
+             :from condition}
+            compiled-accum
+            (:result-binding beta-node)
+            children
+            join-bindings
+            (:new-bindings beta-node))))
 
       :production
-      (let [action-expr (with-meta (compile-action (:bindings beta-node)
-                                                   (:rhs production)
-                                                   (:env production))
-                          (meta (:rhs production)))]
-        (with-meta
-          (eng/->ProductionNode
-           id
-           production
-           (with-bindings (cond-> {#'*file* (-> production :rhs meta :file)
-                                   #'*compile-ctx* {:production production
-                                                    :msg "compiling production node"}}
-                            (:ns-name production) (assoc #'*ns* (the-ns (:ns-name production))))
-             (compile-expr id
-                           action-expr)))
-          {:action-expr action-expr}))
+      (eng/->ProductionNode
+        id
+        production
+        (retrieve-fn id :action-expr))
 
       :query
       (eng/->QueryNode
-       id
-       query
-       (:params query)))))
+        id
+        query
+        (:params query)))))
 
 (sc/defn ^:private compile-beta-graph :- {sc/Int sc/Any}
   "Compile the beta description to the nodes used at runtime."
-  [{:keys [id-to-production-node id-to-condition-node id-to-new-bindings forward-edges backward-edges]} :- schema/BetaGraph]
-  (let [;; A local, memoized function that ensures that the same expression of
-        ;; a given node :id is only compiled into a single function.
-        ;; This prevents redundant compilation and avoids having a Rete node
-        ;; :id that has had its expressions compiled into different
-        ;; compiled functions.
-        compile-expr (memoize (fn [id expr] (try-eval expr)))
-
-        ;; Sort the ids to compile based on dependencies.
+  [{:keys [id-to-production-node id-to-condition-node id-to-new-bindings forward-edges backward-edges]} :- schema/BetaGraph
+   id-key->expr :- {(schema/tuple sc/Int sc/Keyword) IFn}]
+  (let [;; Sort the ids to compile based on dependencies.
         ids-to-compile (loop [pending-ids (into #{} (concat (keys id-to-production-node) (keys id-to-condition-node)))
                               node-deps forward-edges
                               sorted-nodes []]
@@ -1495,7 +1604,7 @@
                                        ;; 0 is the id of the root node.
                                        (= #{0} (get backward-edges id-to-compile))
                                        children
-                                       compile-expr
+                                       id-key->expr
                                        (get id-to-new-bindings id-to-compile))))))
             ;; The node IDs have been determined before now, so we just need to sort the map returned.
             ;; This matters because the engine will left-activate the beta roots with the empty token
@@ -1506,7 +1615,8 @@
 
 (sc/defn to-alpha-graph :- [schema/AlphaNode]
   "Returns a sequence of [condition-fn, [node-ids]] tuples to represent the alpha side of the network."
-  [beta-graph :- schema/BetaGraph]
+  [beta-graph :- schema/BetaGraph
+   create-id-fn :- IFn]
 
   ;; Create a sequence of tuples of conditions + env to beta node ids.
   (let [condition-to-node-ids (for [[id node] (:id-to-condition-node beta-graph)
@@ -1537,37 +1647,25 @@
            :when (:type condition) ; Exclude test conditions.
            ]
 
-       (cond-> {:condition condition
+       (cond-> {:id (create-id-fn)
+                :condition condition
                 :beta-children (distinct node-ids)}
          (seq env) (assoc :env env))))))
 
 
-(sc/defn compile-alpha-nodes :- [{:type sc/Any
+(sc/defn compile-alpha-nodes :- [{:id sc/Int
+                                  :type sc/Any
                                   :alpha-fn sc/Any ;; TODO: is a function...
                                   (sc/optional-key :env) {sc/Keyword sc/Any}
                                   :children [sc/Num]}]
-  [alpha-nodes :- [schema/AlphaNode]]
-  (for [{:keys [condition beta-children env]} alpha-nodes
-        :let [{:keys [type constraints fact-binding args]} condition
-              cmeta (meta condition)
-              alpha-expr (with-meta (compile-condition
-                                      type (first args)  constraints
-                                      fact-binding env)
-                           ;; Remove all metadata but file and line number
-                           ;; to protect from evaluating usafe metadata
-                           ;; See PR 243 for more detailed discussion
-                           (select-keys cmeta [:line :file]))]]
-
-    (with-meta
-      (cond-> {:type (effective-type type)
-               :alpha-fn (binding [*file* (or (:file cmeta) *file*)
-                                   *compile-ctx* {:condition condition
-                                                  :env env
-                                                  :msg "compiling alpha node"}]
-                           (try-eval alpha-expr))
-               :children beta-children}
-        env (assoc :env env))
-      {:alpha-expr alpha-expr})))
+  [alpha-nodes :- [schema/AlphaNode]
+   id-key->expr :- {(schema/tuple sc/Int sc/Keyword) IFn}]
+  (for [{:keys [id condition beta-children env] :as node} alpha-nodes]
+    (cond-> {:id id
+             :type (effective-type (:type condition))
+             :alpha-fn (get id-key->expr [id :alpha-expr])
+             :children beta-children}
+            env (assoc :env env))))
 
 ;; Wrap the fact-type so that Clojure equality and hashcode semantics are used
 ;; even though this is placed in a Java map.
@@ -1677,7 +1775,8 @@
    fact-type-fn
    ancestors-fn
    activation-group-sort-fn
-   activation-group-fn]
+   activation-group-fn
+   expressions]
 
   (let [beta-nodes (vals id-to-node)
 
@@ -1697,11 +1796,9 @@
                              entry))
 
         ;; type, alpha node tuples.
-        alpha-nodes (for [{:keys [type alpha-fn children env] :as alpha-map} alpha-fns
+        alpha-nodes (for [{:keys [id type alpha-fn children env] :as alpha-map} alpha-fns
                           :let [beta-children (map id-to-node children)]]
-                      [type (with-meta
-                              (eng/->AlphaNode env beta-children alpha-fn)
-                              {:alpha-expr (:alpha-expr (meta alpha-map))})])
+                      [type (eng/->AlphaNode id env beta-children alpha-fn)])
 
         ;; Merge the alpha nodes into a multi-map
         alpha-map (reduce
@@ -1721,7 +1818,8 @@
       :id-to-node id-to-node
       :activation-group-sort-fn activation-group-sort-fn
       :activation-group-fn activation-group-fn
-      :get-alphas-fn get-alphas-fn})))
+      :get-alphas-fn get-alphas-fn
+      :node-identifier-to-fn expressions})))
 
 ;; Cache of sessions for fast reloading.
 (def ^:private session-cache (atom {}))
@@ -1769,11 +1867,23 @@
                                      productions)
                       ;; Store the name of the custom comparator for durability.
                       {:clara.rules.durability/comparator-name `production-load-order-comp})
-        beta-graph (to-beta-graph productions)
-        beta-tree (compile-beta-graph beta-graph)
+
+        ;; A stateful counter used for unique ids of the nodes of the graph.
+        id-counter (atom 0)
+        create-id-fn (fn [] (swap! id-counter inc))
+
+        compilation-partition-size (:compilation-partition-size options 1250)
+
+        beta-graph (to-beta-graph productions create-id-fn)
+        alpha-graph (to-alpha-graph beta-graph create-id-fn)
+
+        ;; Extract the expressions from the graphs and evaluate them in a batch manner.
+        ;; This is a performance optimization, see Issue 381 for more information.
+        exprs (compile-exprs (extract-exprs beta-graph alpha-graph) compilation-partition-size)
+        beta-tree (compile-beta-graph beta-graph exprs)
         beta-root-ids (-> beta-graph :forward-edges (get 0)) ; 0 is the id of the virtual root node.
         beta-roots (vals (select-keys beta-tree beta-root-ids))
-        alpha-nodes (compile-alpha-nodes (to-alpha-graph beta-graph))
+        alpha-nodes (compile-alpha-nodes alpha-graph exprs)
 
         ;; The fact-type uses Clojure's type function unless overridden.
         fact-type-fn (or (get options :fact-type-fn)
@@ -1791,7 +1901,8 @@
         activation-group-fn (eng/options->activation-group-fn options)
 
         rulebase (build-network beta-tree beta-roots alpha-nodes productions
-                                fact-type-fn ancestors-fn activation-group-sort-fn activation-group-fn)
+                                fact-type-fn ancestors-fn activation-group-sort-fn activation-group-fn
+                                exprs)
 
         get-alphas-fn (:get-alphas-fn rulebase)
 

--- a/src/main/clojure/clara/rules/durability.clj
+++ b/src/main/clojure/clara/rules/durability.clj
@@ -550,6 +550,11 @@
      the session was serialized without the rulebase, i.e. :with-rulebase? = false, so it needs a rulebase
      to be 'attached' back onto it to be usable.
 
+   * :compilation-partition-size - The maximum number of expressions that will be evaluated per call to eval.
+     This will be defaulted to 1250 if not provided. Larger batch sizes should see better performance compared
+     to smaller batch sizes. This option will only apply to deserialization of the rulebase, as serialization
+     does not need to evaluate any expressions.
+
    Options for the rulebase semantics that are documented at clara.rules/mk-session include:
 
    * :fact-type-fn

--- a/src/main/clojure/clara/rules/durability.clj
+++ b/src/main/clojure/clara/rules/durability.clj
@@ -551,9 +551,8 @@
      to be 'attached' back onto it to be usable.
 
    * :forms-per-eval - The maximum number of expressions that will be evaluated per call to eval.
-     This will be defaulted to 1250 if not provided. Larger batch sizes should see better performance compared
-     to smaller batch sizes. This option will only apply to deserialization of the rulebase, as serialization
-     does not need to evaluate any expressions.
+     Larger batch sizes should see better performance compared to smaller batch sizes.
+     Defaults to 5000, see clara.rules.compiler/forms-per-eval-default for more information.
 
    Options for the rulebase semantics that are documented at clara.rules/mk-session include:
 

--- a/src/main/clojure/clara/rules/durability.clj
+++ b/src/main/clojure/clara/rules/durability.clj
@@ -550,7 +550,7 @@
      the session was serialized without the rulebase, i.e. :with-rulebase? = false, so it needs a rulebase
      to be 'attached' back onto it to be usable.
 
-   * :compilation-partition-size - The maximum number of expressions that will be evaluated per call to eval.
+   * :forms-per-eval - The maximum number of expressions that will be evaluated per call to eval.
      This will be defaulted to 1250 if not provided. Larger batch sizes should see better performance compared
      to smaller batch sizes. This option will only apply to deserialization of the rulebase, as serialization
      does not need to evaluate any expressions.

--- a/src/main/clojure/clara/rules/durability.clj
+++ b/src/main/clojure/clara/rules/durability.clj
@@ -32,34 +32,22 @@
    avoid creating multiple object instances for the same node."
   (ThreadLocal.))
 
-(def ^:internal ^ThreadLocal compile-expr-fn
-  "Similar to what is done in clara.rules.compiler, this is a function used to compile
-   expressions used in nodes of the rulebase network.  A common function would cache
-   evaluated expressions by node-id and expression form to avoid duplicate evalutation
-   of the same expressions."
+(def ^:internal ^ThreadLocal node-fn-cache
+  "A cache for holding the fns used to reconstruct the nodes. Only applicable during read time, specifically
+   this will be bound to a Map of [<node-id> <field-name>] to IFn before the rulebase is deserialized. While the
+   rulebase is deserialized the nodes will reference this cache to repopulate their fns."
   (ThreadLocal.))
 
 (defn- add-node-fn [node fn-key meta-key]
   (assoc node
          fn-key
-         ((.get compile-expr-fn) (:id node) (meta-key (meta node)))))
+         (get (.get node-fn-cache) [(:id node) meta-key])))
 
 (defn add-rhs-fn [node]
-  ;; The RHS expression may need to be compiled within the namespace scope of specifically declared
-  ;; :ns-name.  The LHS expressions do not (currently) need or support this path.
-  ;; See https://github.com/cerner/clara-rules/issues/178 for more details.
-  (with-bindings (if-let [ns (some-> node
-                                     :production
-                                     :ns-name
-                                     the-ns)]
-                   {#'*ns* ns}
-                   {})
-    (add-node-fn node :rhs :action-expr)))
+  (add-node-fn node :rhs :action-expr))
 
 (defn add-alpha-fn [node]
-  ;; AlphaNode's do not have node :id's right now since they don't
-  ;; have any memory specifically associated with them.
-  (assoc node :activation (com/try-eval (:alpha-expr (meta node)))))
+  (add-node-fn node :activation :alpha-expr))
 
 (defn add-join-filter-fn [node]
   (add-node-fn node :join-filter-fn :join-filter-expr))
@@ -69,8 +57,7 @@
 
 (defn add-accumulator [node]
   (assoc node
-         :accumulator (((.get compile-expr-fn) (:id node)
-                                          (:accum-expr (meta node)))
+         :accumulator ((get (.get node-fn-cache) [(:id node) :accum-expr])
                        (:env node))))
 
 (defn node-id->node

--- a/src/main/clojure/clara/rules/durability.clj
+++ b/src/main/clojure/clara/rules/durability.clj
@@ -38,10 +38,10 @@
    rulebase is deserialized the nodes will reference this cache to repopulate their fns."
   (ThreadLocal.))
 
-(defn- add-node-fn [node fn-key meta-key]
+(defn- add-node-fn [node fn-key expr-key]
   (assoc node
          fn-key
-         (get (.get node-fn-cache) [(:id node) meta-key])))
+         (first (get (.get node-fn-cache) [(:id node) expr-key]))))
 
 (defn add-rhs-fn [node]
   (add-node-fn node :rhs :action-expr))
@@ -57,7 +57,7 @@
 
 (defn add-accumulator [node]
   (assoc node
-         :accumulator ((get (.get node-fn-cache) [(:id node) :accum-expr])
+         :accumulator ((first (get (.get node-fn-cache) [(:id node) :accum-expr]))
                        (:env node))))
 
 (defn node-id->node

--- a/src/main/clojure/clara/rules/durability/fressian.clj
+++ b/src/main/clojure/clara/rules/durability/fressian.clj
@@ -408,31 +408,11 @@
                                "clara/querynodeid")
 
    "clara/alphanode"
-   {:class AlphaNode
-    ;; The writer and reader here work similar to the IRecord implementation.  The only
-    ;; difference is that the record needs to be written with out the compiled clj
-    ;; function on it.  This is due to clj functions not having any convenient format
-    ;; for serialization.  The function is restored by re-eval'ing the function based on
-    ;; its originating code form at read-time.
-    :writer (reify WriteHandler
-              (write [_ w o]
-                (if-let [idx (d/clj-record-fact->idx o)]
-                  (do
-                    (.writeTag w "clara/alphanodeid" 1)
-                    (.writeInt w idx))
-                  (do
-                    (write-record w "clara/alphanode" (assoc o :activation nil))
-                    (d/clj-record-holder-add-fact-idx! o)))))
-    :readers {"clara/alphanodeid"
-              (reify ReadHandler
-                (read [_ rdr tag component-count]
-                  (d/clj-record-idx->fact (.readObject rdr))))
-              "clara/alphanode"
-              (reify ReadHandler
-                (read [_ rdr tag component-count]
-                  (-> rdr
-                      (read-record d/add-alpha-fn)
-                      d/clj-record-holder-add-fact!)))}}
+   (create-cached-node-handler AlphaNode
+                               "clara/alphanodeid"
+                               "clara/alphanode"
+                               #(assoc % :activation nil)
+                               d/add-alpha-fn)
 
    "clara/rootjoinnode"
    (create-cached-node-handler RootJoinNode

--- a/src/main/clojure/clara/rules/durability/fressian.clj
+++ b/src/main/clojure/clara/rules/durability/fressian.clj
@@ -585,7 +585,7 @@
           indexed-facts))))
   
   (deserialize [_ mem-facts opts]
-    
+
     (with-open [^FressianReader rdr (fres/create-reader in-stream :handlers read-handler-lookup)]
       (let [{:keys [rulebase-only? base-rulebase compilation-partition-size]} opts
             
@@ -595,6 +595,9 @@
             maybe-base-rulebase (when (and (not rulebase-only?) base-rulebase)
                                   base-rulebase)
 
+            ;; 1250 is an arbitrary number, this could be lower or higher depending on the
+            ;; rulebase that is being deserialized, with regards to the average size of the
+            ;; forms being evaluated.
             compilation-partition-size (or compilation-partition-size 1250)
 
             reconstruct-expressions (fn [ks]

--- a/src/main/clojure/clara/rules/durability/fressian.clj
+++ b/src/main/clojure/clara/rules/durability/fressian.clj
@@ -595,10 +595,7 @@
             maybe-base-rulebase (when (and (not rulebase-only?) base-rulebase)
                                   base-rulebase)
 
-            ;; 1250 is an arbitrary number, this could be lower or higher depending on the
-            ;; rulebase that is being deserialized, with regards to the average size of the
-            ;; forms being evaluated.
-            forms-per-eval (or forms-per-eval 1250)
+            forms-per-eval (or forms-per-eval com/forms-per-eval-default)
 
             reconstruct-expressions (fn [ks]
                                       (into {}

--- a/src/main/clojure/clara/rules/engine.cljc
+++ b/src/main/clojure/clara/rules/engine.cljc
@@ -524,7 +524,7 @@
 ;; Record representing alpha nodes in the Rete network,
 ;; each of which evaluates a single condition and
 ;; propagates matches to its children.
-(defrecord AlphaNode [env children activation]
+(defrecord AlphaNode [id env children activation]
 
   IAlphaActivate
   (alpha-activate [node facts memory transport listener]

--- a/src/main/clojure/clara/rules/schema.cljc
+++ b/src/main/clojure/clara/rules/schema.cljc
@@ -131,7 +131,8 @@
 
 ;; Alpha network schema.
 (def AlphaNode
-  {:condition FactCondition
+  {:id s/Int
+   :condition FactCondition
    ;; Opional environment for the alpha node.
    (s/optional-key :env) {s/Keyword s/Any}
    ;; IDs of the beta nodes that are the children.
@@ -154,3 +155,14 @@
 
    ;; Map of identifier to new bindings created by the corresponding node.
    :id-to-new-bindings {s/Int #{s/Keyword}}})
+
+(defn tuple
+  "Given `items`, a list of schemas, will generate a schema to validate that a vector contains and is in the order provided
+   by `items`."
+  [& items]
+  (s/constrained [s/Any]
+                 (fn [tuple-vals]
+                   (and (= (count tuple-vals)
+                           (count items))
+                        (every? nil? (map s/check items tuple-vals))))
+                 "tuple"))

--- a/src/main/clojure/clara/rules/schema.cljc
+++ b/src/main/clojure/clara/rules/schema.cljc
@@ -1,7 +1,10 @@
 (ns clara.rules.schema
   "Schema definition of Clara data structures using Prismatic's Schema library. This includes structures for rules and queries, as well as the schema
    for the underlying Rete network itself. This can be used by tools or other libraries working with rules."
-  (:require [schema.core :as s]))
+  (:require [schema.core :as s])
+  #?(:clj
+     (:import [clojure.lang
+               IFn])))
 
 
 (s/defn condition-type :- (s/enum :or :not :and :exists :fact :accumulator :test)
@@ -166,3 +169,12 @@
                            (count items))
                         (every? nil? (map s/check items tuple-vals))))
                  "tuple"))
+
+;; A map of [<node-id> <field-name>] to SExpression, used in compilation of the rulebase.
+(def NodeExprLookup
+  {(tuple s/Int s/Keyword) SExpr})
+
+;; An evaluated version of the schema mentioned above.
+#?(:clj
+   (def NodeFnLookup
+     {(tuple s/Int s/Keyword) IFn}))

--- a/src/main/clojure/clara/rules/schema.cljc
+++ b/src/main/clojure/clara/rules/schema.cljc
@@ -167,10 +167,23 @@
                         (every? nil? (map s/check items tuple-vals))))
                  "tuple"))
 
+(def NodeCompilationContext
+  (s/constrained {s/Keyword s/Any}
+                 (fn [ctx]
+                   (let [expr-keys #{:alpha-expr :action-expr :join-filter-expr :test-expr :accum-expr}
+                         xor #(and (or %1 %2)
+                                   (not (and %1 %2)))]
+                     (and (some expr-keys (keys ctx))
+                          (contains? ctx :compile-ctx)
+                          (contains? (:compile-ctx ctx) :msg)
+                          (xor (contains? (:compile-ctx ctx) :condition)
+                               (contains? (:compile-ctx ctx) :production)))))
+                 "node-compilation-context"))
+
 ;; A map of [<node-id> <field-name>] to SExpression, used in compilation of the rulebase.
 (def NodeExprLookup
-  {(tuple s/Int s/Keyword) SExpr})
+  {(tuple s/Int s/Keyword) (tuple SExpr NodeCompilationContext)})
 
 ;; An evaluated version of the schema mentioned above.
 (def NodeFnLookup
-  {(tuple s/Int s/Keyword) (s/pred ifn? "ifn?")})
+  {(tuple s/Int s/Keyword) (tuple (s/pred ifn? "ifn?") NodeCompilationContext)})

--- a/src/main/clojure/clara/rules/schema.cljc
+++ b/src/main/clojure/clara/rules/schema.cljc
@@ -1,10 +1,7 @@
 (ns clara.rules.schema
   "Schema definition of Clara data structures using Prismatic's Schema library. This includes structures for rules and queries, as well as the schema
    for the underlying Rete network itself. This can be used by tools or other libraries working with rules."
-  (:require [schema.core :as s])
-  #?(:clj
-     (:import [clojure.lang
-               IFn])))
+  (:require [schema.core :as s]))
 
 
 (s/defn condition-type :- (s/enum :or :not :and :exists :fact :accumulator :test)
@@ -175,6 +172,5 @@
   {(tuple s/Int s/Keyword) SExpr})
 
 ;; An evaluated version of the schema mentioned above.
-#?(:clj
-   (def NodeFnLookup
-     {(tuple s/Int s/Keyword) IFn}))
+(def NodeFnLookup
+  {(tuple s/Int s/Keyword) (s/pred ifn? "ifn?")})

--- a/src/test/clojure/clara/long_running_tests.clj
+++ b/src/test/clojure/clara/long_running_tests.clj
@@ -1,0 +1,28 @@
+(ns clara.long-running-tests
+  (:require [clojure.test :refer :all]
+            [clara.rules.compiler :as com]
+            [schema.core :as sc]))
+
+(deftest test-maximum-forms-per-eval
+  ;; 5472 to ensure that we have enough forms to create a full batch, see clara.rules.compiler/forms-per-eval-default
+  ;; or Issue 381 for more info
+  (let [rules (for [_ (range 5472)
+                    :let [fact-type (keyword (gensym))]]
+                {:ns-name (ns-name *ns*)
+                 :lhs [{:type fact-type
+                        :constraints []}]
+                 :rhs `(println ~(str fact-type))})
+        rules-and-opts (conj (vector rules) :forms-per-eval 5472 :cache false)
+
+        e (try
+            ;; Not validating schema here because it will be very expensive
+            (sc/without-fn-validation (com/mk-session rules-and-opts))
+            (is false "Max batching size should have been exceeded, and exception thrown")
+            (catch Exception e e))]
+
+    ;; Validating that there were 5472 forms in the eval call.
+    (is (= 5472 (count (-> e ex-data :compilation-ctxs))))
+    (is (re-find #"method size exceeded"  (.getMessage e)))
+
+    ;; Validate that the stated 5471 forms per eval will compile
+    (is (sc/without-fn-validation (com/mk-session (conj (vector rules) :forms-per-eval 5471 :cache false))))))

--- a/src/test/clojure/clara/performance/test_compilation.clj
+++ b/src/test/clojure/clara/performance/test_compilation.clj
@@ -37,6 +37,9 @@
      :mean (double mean)}))
 
 (defn run-performance-test
+  "Created as a rudimentary alternative to criterium, do to assumptions made during benchmarking. Specifically, that
+   criterium attempts to reach a steady state of compiled and loaded classes. This fundamentally doesn't work when the
+   metrics needed rely on compilation or evaluation."
   [form]
   (let [{:keys [description func iterations mean-assertion]} form
         {:keys [std mean]} (execute-tests func iterations)]
@@ -45,7 +48,8 @@
     (println "==========================================")
     (println (str "Mean: " mean "ms"))
     (println (str "Standard Deviation: " std "ms" \newline))
-    (is (mean-assertion mean))))
+    (is (mean-assertion mean)
+        (str "Actual mean value: " mean))))
 
 (def base-production
   {:ns-name (symbol (str *ns*))})

--- a/src/test/clojure/clara/performance/test_compilation.clj
+++ b/src/test/clojure/clara/performance/test_compilation.clj
@@ -37,7 +37,7 @@
      :mean (double mean)}))
 
 (defn run-performance-test
-  "Created as a rudimentary alternative to criterium, do to assumptions made during benchmarking. Specifically, that
+  "Created as a rudimentary alternative to criterium, due to assumptions made during benchmarking. Specifically, that
    criterium attempts to reach a steady state of compiled and loaded classes. This fundamentally doesn't work when the
    metrics needed rely on compilation or evaluation."
   [form]

--- a/src/test/clojure/clara/performance/test_compilation.clj
+++ b/src/test/clojure/clara/performance/test_compilation.clj
@@ -135,7 +135,7 @@
           os (ByteArrayOutputStream.)]
       (testing "Session rulebase serialization performance"
         (run-performance-test
-          {:description "Generated Session serialization"
+          {:description "Session rulebase serialization"
            :func #(dura/serialize-rulebase
                     session
                     (fres/create-session-serializer (ByteArrayOutputStream.)))
@@ -149,7 +149,7 @@
 
         (let [session-bytes (.toByteArray os)]
           (run-performance-test
-            {:description "Generated Session deserialization"
+            {:description "Session rulebase deserialization"
              :func #(dura/deserialize-rulebase
                       (fres/create-session-serializer (ByteArrayInputStream. session-bytes)))
              :iterations 50

--- a/src/test/clojure/clara/performance/test_compilation.clj
+++ b/src/test/clojure/clara/performance/test_compilation.clj
@@ -1,0 +1,154 @@
+(ns clara.performance.test-compilation
+  (:require [clojure.test :refer :all]
+            [clara.rules.compiler :as com]
+            [clara.rules :as r]
+            [clara.rules.durability.fressian :as dura])
+  (:import [java.io ByteArrayOutputStream ByteArrayInputStream]))
+
+(defn filter-fn
+  [seed-keyword]
+  (= seed-keyword (keyword (gensym))))
+
+(defn time-execution
+  [func]
+  (let [start (System/currentTimeMillis)
+        _ (func)
+        stop (System/currentTimeMillis)]
+    (- stop start)))
+
+(defn execute-tests
+  [func iterations]
+  (let [execution-times (for [_ (range iterations)]
+                          (time-execution func))
+        sum #(reduce + %)
+        mean (/ (sum execution-times) iterations)
+        std (->
+              (into []
+                    (comp
+                      (map #(- % mean))
+                      (map #(Math/pow (double %) 2.0)))
+                    execution-times)
+              sum
+              (/ iterations)
+              Math/sqrt)]
+    {:std (double std)
+     :mean (double mean)}))
+
+(defn run-performance-test
+  [form]
+  (let [{:keys [description func iterations mean-assertion]} form
+        {:keys [std mean]} (execute-tests func iterations)]
+    (println (str \newline "Running Performance tests for:"))
+    (println description)
+    (println "==========================================")
+    (println (str "Mean: " mean "ms"))
+    (println (str "Standard Deviation : " std "ms" \newline))
+    (is (mean-assertion mean))))
+
+(def base-production
+  {:ns-name (symbol (str *ns*))})
+
+(defn generate-filter-productions
+  [seed-syms]
+  (into {}
+        (for [seed-sym seed-syms
+              :let [next-fact (symbol (str seed-sym "prime"))
+                    production (assoc base-production
+                                 :lhs [{:type (keyword seed-sym)
+                                        :constraints ['(= this ?binding) `(filter-fn ~'this)]}]
+                                 :rhs `(r/insert! (with-meta ~(set (repeatedly 10 #(rand-nth (range 100))))
+                                                             {:type ~(keyword next-fact)
+                                                              :val ~'?binding})))]]
+          [next-fact production])))
+
+(defn generate-compose-productions
+  [seed-syms]
+  (let [template (fn template
+                   ([l] (template l l))
+                   ([l r] (let [next-fact (symbol (str l r "prime"))
+                                production (assoc base-production
+                                             :lhs [{:type (keyword l)
+                                                    :constraints ['(= this ?binding-l)]}
+                                                   {:type (keyword r)
+                                                    :constraints ['(= ?binding-l this)]}]
+                                             :rhs `(r/insert! (with-meta ~(set (repeatedly 10 #(rand-nth (range 100))))
+                                                                         {:type ~(keyword next-fact)})))]
+                            [next-fact production])))]
+    (into {}
+          (for [combo (partition-all 2 (shuffle seed-syms))]
+            (apply template combo)))))
+
+(defn generate-collection-productions
+  [seed-syms]
+  (into {}
+        (for [seed-sym seed-syms
+              :let [next-fact (symbol (str seed-sym "prime"))
+                    production (assoc base-production
+                                 :lhs [{:accumulator '(clara.rules.accumulators/all)
+                                        :from {:type (keyword seed-sym),
+                                               :constraints [`(filter-fn ~'this)]}
+                                        :result-binding :?binding}]
+                                 :rhs `(r/insert! (with-meta ~'?binding
+                                                             {:type ~(keyword next-fact)})))]]
+          [next-fact production])))
+
+(defn generate-queries
+  [seed-syms]
+  (into {}
+        (for [seed-sym seed-syms
+              :let [production (assoc base-production
+                                 :lhs [{:type [seed-sym]
+                                        :constraints []
+                                        :fact-binding :?binding}]
+                                 :params #{})]]
+          [seed-sym production])))
+
+(defn generate-rules-and-opts
+  [num-starter-facts]
+  (let [starter-seeds (repeatedly num-starter-facts gensym)]
+    (-> (reduce (fn [[seeds prods] next-fn]
+                  (let [new-productions-and-facts (next-fn seeds)]
+                    [(keys new-productions-and-facts)
+                     (concat prods
+                             (vals new-productions-and-facts))]))
+                [starter-seeds []]
+                [generate-filter-productions
+                 generate-compose-productions
+                 generate-collection-productions
+                 generate-queries])
+        second
+        vector
+        (conj :cache false))))
+
+(deftest compilation-performance-test
+  (let [rules (generate-rules-and-opts 500)]
+    (testing "Session creation performance"
+      (run-performance-test
+        {:description "Generated Session Compilation"
+         :func #(com/mk-session rules)
+         :iterations 50
+         :mean-assertion (partial > 5000)}))
+
+    (let [session (com/mk-session rules)
+          os (ByteArrayOutputStream.)]
+      (testing "Session serialization performance"
+        (run-performance-test
+          {:description "Generated Session serialization"
+           :func #(.serialize (dura/create-session-serializer (ByteArrayOutputStream.))
+                              session
+                              {:rulebase-only? true})
+           :iterations 50
+           :mean-assertion (partial > 1000)}))
+
+      (testing "Session deserialization performance"
+        (.serialize (dura/create-session-serializer os)
+                    session
+                    {:rulebase-only? true})
+
+        (let [session-bytes (.toByteArray os)]
+          (run-performance-test
+            {:description "Generated Session deserialization"
+             :func #(-> (dura/create-session-serializer (ByteArrayInputStream. session-bytes))
+                        (.deserialize session-bytes {:rulebase-only? true}))
+             :iterations 50
+             :mean-assertion (partial > 5000)}))))))

--- a/src/test/clojure/clara/test_rules.clj
+++ b/src/test/clojure/clara/test_rules.clj
@@ -1019,7 +1019,8 @@
            (keys (:id-to-node rulebase2))))
 
     ;; Ensure there are beta and production nodes as expected.
-    (is (= 4 (count (:id-to-node rulebase))))))
+    ;; 2 alpha-nodes, 2 root-join nodes, and 2 production nodes
+    (is (= 6 (count (:id-to-node rulebase))))))
 
 (deftest test-simple-test
   (let [distinct-temps-query (dsl/parse-query [] [[Temperature (< temperature 20) (= ?t1 temperature)]
@@ -1758,7 +1759,7 @@
         s (mk-session [q])]
 
     ;; Mostly just ensuring the rulebase was compiled successfully.
-    (is (== 3
+    (is (== 4 ;; 1 alpha-node, 2 accumulate nodes, and 1 query node
             (-> s
                 .rulebase
                 :id-to-node

--- a/src/test/clojure/clara/test_rules.clj
+++ b/src/test/clojure/clara/test_rules.clj
@@ -1283,7 +1283,9 @@
         cold-windy-query (dsl/parse-query [] [[Temperature (< temperature 20) (= ?t temperature)]
                                               [WindSpeed (> windspeed 25)]])
 
-        beta-graph (com/to-beta-graph #{cold-query cold-windy-query})]
+        beta-graph (com/to-beta-graph #{cold-query cold-windy-query} (let [x (atom 0)]
+                                                                       (fn []
+                                                                         (swap! x inc))))]
 
     ;; The above rules should share a root condition, so there are
     ;; only two distinct conditions in our network, plus the root node.

--- a/src/test/clojure/clara/test_rules.clj
+++ b/src/test/clojure/clara/test_rules.clj
@@ -2752,26 +2752,3 @@
                     (fire-rules))]
 
     (is (= [{:?x inner-one}] (query session test-query)))))
-
-(deftest test-maximum-forms-per-eval
-  ;; 5472 to ensure that we have enough forms to create a full batch, see clara.rules.compiler/forms-per-eval-default
-  ;; or Issue 381 for more info
-  (let [rules (for [_ (range 5472)
-                    :let [fact-type (keyword (gensym))]]
-                {:ns-name (ns-name *ns*)
-                 :lhs [{:type fact-type
-                        :constraints []}]
-                 :rhs `(println ~(str fact-type))})
-        rules-and-opts (conj (vector rules) :forms-per-eval 5472 :cache false)
-
-        e (try
-            ;; Not validating schema here because it will be very expensive
-            (sc/without-fn-validation (com/mk-session rules-and-opts))
-            (is false "Max batching size should have been exceeded, and exception thrown")
-            (catch Exception e e))]
-
-    ;; Validating that there were 5472 forms in the eval call.
-    (is (= 5472 (count (-> e ex-data :node-keys))))
-
-    ;; Validate that the stated 5471 forms per eval will compile
-    (is (sc/without-fn-validation (com/mk-session (conj (vector rules) :forms-per-eval 5471 :cache false))))))

--- a/src/test/clojure/clara/test_rules.clj
+++ b/src/test/clojure/clara/test_rules.clj
@@ -16,6 +16,7 @@
             [clara.sample-ruleset-seq :as srs]
             [clara.order-ruleset :as order-rules]
             [schema.test]
+            [schema.core :as sc]
             [clara.tools.testing-utils :as tu])
   (:import [clara.rules.testfacts Temperature WindSpeed Cold Hot TemperatureHistory
             ColdAndWindy LousyWeather First Second Third Fourth FlexibleFields]
@@ -2727,3 +2728,26 @@
                                                                :name :clara.rules.test-rules-data/is-cold-and-windy-data
                                                                :lhs  []
                                                                :rhs  '(println "I have no meaning outside of this test")}))) {})))
+
+(deftest test-maximum-forms-per-eval
+  ;; 5472 to ensure that we have enough forms to create a full batch, see clara.rules.compiler/forms-per-eval-default
+  ;; or Issue 381 for more info
+  (let [rules (for [_ (range 5472)
+                    :let [fact-type (keyword (gensym))]]
+                {:ns-name (ns-name *ns*)
+                 :lhs [{:type fact-type
+                        :constraints []}]
+                 :rhs `(println ~(str fact-type))})
+        rules-and-opts (conj (vector rules) :forms-per-eval 5472 :cache false)
+
+        e (try
+            ;; Not validating schema here because it will be very expensive
+            (sc/without-fn-validation (com/mk-session rules-and-opts))
+            (is false "Max batching size should have been exceeded, and exception thrown")
+            (catch Exception e e))]
+
+    ;; Validating that there were 5472 forms in the eval call.
+    (is (= 5472 (count (-> e ex-data :node-keys))))
+
+    ;; Validate that the stated 5471 forms per eval will compile
+    (is (sc/without-fn-validation (com/mk-session (conj (vector rules) :forms-per-eval 5471 :cache false))))))


### PR DESCRIPTION
I have changed both the Durability and Compiler evaluation of functions that are embedded in the rulebase, as part of this I also gave AlphaNodes an Id. 

I have also added some performance tests that generate a simple rulebase and compile, serialize and deserialize the rulebase. Running performance locally (`lein test :performance` )
gave me a before of:
```
Running Performance tests for:
Generated Session Compilation
==========================================
Mean: 13412.32ms
Standard Deviation : 5924.659171429188ms

Running Performance tests for:
Generated Session serialization
==========================================
Mean: 205.94ms
Standard Deviation : 85.99474635115799ms

Running Performance tests for:
Generated Session deserialization
==========================================
Mean: 29966.56ms
Standard Deviation : 12047.334043945159ms
```

and an after of:
```
Running Performance tests for:
Generated Session Compilation
==========================================
Mean: 2682.92ms
Standard Deviation : 108.87604695248626ms


Running Performance tests for:
Generated Session serialization
==========================================
Mean: 223.9ms
Standard Deviation : 11.80211845390479ms


Running Performance tests for:
Generated Session deserialization
==========================================
Mean: 1683.98ms
Standard Deviation : 87.03987362123178ms
```

I chose to persist the functions on the rulebase, this allows for the functions to be easily pulled off for serialization and deserialization. Allowing for minimal traversal of the already constructed rulebase, memory usage seems comparable to what it was before and the performance numbers speak for themselves.

@WilliamParker @mrrodriguez @rbrush 
When you get some time, could you look over this? 