### PR TITLE
ISSUE-393: Fix incorrect equality semantics when unifying similar obj…

### DIFF
--- a/src/main/clojure/clara/rules/platform.cljc
+++ b/src/main/clojure/clara/rules/platform.cljc
@@ -17,7 +17,8 @@
 
      Object
      (equals [this other]
-       (= wrapped (.wrapped ^JavaEqualityWrapper other)))
+       (and (instance? JavaEqualityWrapper other)
+            (= wrapped (.wrapped ^JavaEqualityWrapper other))))
 
      (hashCode [this]
        hash-code)))

--- a/src/main/clojure/clara/rules/platform.cljc
+++ b/src/main/clojure/clara/rules/platform.cljc
@@ -7,10 +7,25 @@
   [^String description]
   (throw #?(:clj (IllegalArgumentException. description) :cljs (js/Error. description))))
 
+;; This class wraps Clojure objects to ensure Clojure's equality and hash
+;; semantics are visible to Java code. This allows these Clojure objects
+;; to be safely used in things like Java Sets or Maps.
+;; This class also accepts and stores the hash code, since it almost always
+;; will be used once and generally more than once.
+#?(:clj
+   (deftype JavaEqualityWrapper [wrapped ^int hash-code]
+
+     Object
+     (equals [this other]
+       (= wrapped (.wrapped ^JavaEqualityWrapper other)))
+
+     (hashCode [this]
+       hash-code)))
+
 #?(:clj
    (defn group-by-seq
-     "Groups the items of the given coll by f to each item.  Returns a seq of tuples of the form 
-      [f-val xs] where xs are items from the coll and f-val is the result of applying f to any of 
+     "Groups the items of the given coll by f to each item.  Returns a seq of tuples of the form
+      [f-val xs] where xs are items from the coll and f-val is the result of applying f to any of
       those xs.  Each x in xs has the same value (f x).  xs will be in the same order as they were
       found in coll.
       The behavior is similar to calling `(seq (group-by f coll))` However, the returned seq will
@@ -21,9 +36,10 @@
      [f coll]
      (let [^java.util.Map m (reduce (fn [^java.util.Map m x]
                                       (let [k (f x)
-                                            xs (or (.get m k)
+                                            wrapper (JavaEqualityWrapper. k (hash k))
+                                            xs (or (.get m wrapper)
                                                    (transient []))]
-                                        (.put m k (conj! xs x)))
+                                        (.put m wrapper (conj! xs x)))
                                       m)
                                     (java.util.LinkedHashMap.)
                                     coll)
@@ -33,7 +49,7 @@
        (loop [coll (transient [])]
          (if (.hasNext it)
            (let [^java.util.Map$Entry e (.next it)]
-             (recur (conj! coll [(.getKey e) (persistent! (.getValue e))])))
+             (recur (conj! coll [(.wrapped ^JavaEqualityWrapper (.getKey e)) (persistent! (.getValue e))])))
            (persistent! coll)))))
    :cljs
    (def group-by-seq (comp seq clojure.core/group-by)))
@@ -59,7 +75,7 @@
 
 #?(:clj
     (defmacro thread-local-binding
-      "Wraps given body in a try block, where it sets each given ThreadLocal binding 
+      "Wraps given body in a try block, where it sets each given ThreadLocal binding
        and removes it in finally block."
       [bindings & body]
       (when-not (vector? bindings)

--- a/src/test/clojure/clara/test_rules.clj
+++ b/src/test/clojure/clara/test_rules.clj
@@ -2724,3 +2724,27 @@
                                                                :name :clara.rules.test-rules-data/is-cold-and-windy-data
                                                                :lhs  []
                                                                :rhs  '(println "I have no meaning outside of this test")}))) {})))
+
+(defrecord OuterRecordOne [x])
+(defrecord OuterRecordTwo [x])
+
+(defrecord InnerRecordOne [num])
+(defrecord InnerRecordTwo [num])
+
+;; Test for issue 393
+(deftest test-record-equality-semantics
+  (let [inner-one (->InnerRecordOne 1)
+        inner-two (->InnerRecordTwo 1)
+
+        test-query (dsl/parse-query [] [[OuterRecordOne (= ?x x)]
+                                        [OuterRecordTwo (= ?x x)]])
+
+
+        session (-> (mk-session [test-query])
+                    (insert (->OuterRecordOne inner-one)
+                            ;; Needed to reproduce the bug.
+                            (->OuterRecordTwo inner-one)
+                            (->OuterRecordTwo inner-two))
+                    (fire-rules))]
+
+    (is (= [{:?x inner-one}] (query session test-query)))))


### PR DESCRIPTION
Fix for #393 by simply wrapping potential keys in a Java object that explicitly uses Clojure's equality and hash logic.