### PR TITLE
Build against Clojure 1.10.0-RC1 in Travis in addition to earlier ver…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ script:
   - lein test
   - lein test :generative
   - lein with-profile dev,recent-clj test
+  - lein with-profile dev,rc-clojure test
 # Workaround for https://github.com/travis-ci/travis-ci/issues/4691
 sudo: required
 jdk:

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,9 @@
                                   [org.clojure/data.fressian "0.2.1"]]}
              :provided {:dependencies [[org.clojure/clojurescript "1.7.170"]]}
              :recent-clj {:dependencies [^:replace [org.clojure/clojure "1.9.0"]
-                                         ^:replace [org.clojure/clojurescript "1.9.946"]]}}
+                                         ^:replace [org.clojure/clojurescript "1.9.946"]]}
+             :rc-clojure {:dependencies [^:replace [org.clojure/clojure "1.10.0-RC1"]
+                                         ^:replace [org.clojure/clojurescript "1.9.946"]]}} 
   :plugins [[lein-codox "0.10.3" :exclusions [org.clojure/clojure
                                               org.clojure/clojurescript]]
             [lein-javadoc "0.3.0" :exclusions [org.clojure/clojure


### PR DESCRIPTION
…sions

As the title suggests this PR sets up a Travis build against the latest Clojure 1.10 RC.  Once the RC becomes a final release I think we can bump the recent-clj build to Clojure 1.10 and delete this new build.