### PR TITLE
Issue 298: Additional facts added to an :exists accumulator condition…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ This is a history of changes to clara-rules.
 
 # 0.20.0-SNAPSHOT
 * Added a new field to the clara.rules.engine/Accumulator record.  This could be a breaking change for any user durability implementations with low-level performance optimizations.  See [PR 410](https://github.com/cerner/clara-rules/pull/410) for details.
+* Performance improvements for :exists conditions.  See [issue 298](https://github.com/cerner/clara-rules/issues/298).
 
 ### 0.19.0
 * Remove a warning about `qualified-keyword?` being replaced when using Clojure 1.9.

--- a/src/main/clojure/clara/rules/accumulators.cljc
+++ b/src/main/clojure/clara/rules/accumulators.cljc
@@ -169,6 +169,14 @@
     :retract-fn (fn [count retracted] (dec count))
     :combine-fn +}))
 
+(defn exists
+  "Returns an accumulator that accumulates to true if at least one fact
+   exists and nil otherwise, the latter causing the accumulator condition to not match."
+  []
+  (assoc (count) :convert-return-fn (fn [v]
+                                      (when (pos? v)
+                                        true))))
+
 (defn distinct
   "Returns an accumulator producing a distinct set of facts.
    If given a field, returns a distinct set of values for that field."

--- a/src/main/clojure/clara/rules/accumulators.cljc
+++ b/src/main/clojure/clara/rules/accumulators.cljc
@@ -174,6 +174,11 @@
    exists and nil otherwise, the latter causing the accumulator condition to not match."
   []
   (assoc (count) :convert-return-fn (fn [v]
+                                      ;; This specifically needs to return nil rather than false if the pos? predicate is false so that
+                                      ;; the accumulator condition will fail to match; the accumulator will consider
+                                      ;; boolean false a valid match.  See https://github.com/cerner/clara-rules/issues/182#issuecomment-217142418
+                                      ;; and the following comments for the original discussion around suppressing nil accumulator
+                                      ;; return values but propagating boolean false.
                                       (when (pos? v)
                                         true))))
 

--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -650,10 +650,9 @@
                    ;; This is an :exists condition, so expand it
                    ;; into an accumulator and a test.
                    (let [exists-count (gensym "?__gen__")]
-                       [{:accumulator '(clara.rules.accumulators/count)
+                       [{:accumulator '(clara.rules.accumulators/exists)
                          :from (second condition)
-                         :result-binding (keyword exists-count)}
-                        {:constraints [(list '> exists-count 0)]}])
+                         :result-binding (keyword exists-count)}])
 
                    ;; This is not an :exists condition, so do not change it.
                    [condition])]

--- a/src/test/common/clara/test_exists.cljc
+++ b/src/test/common/clara/test_exists.cljc
@@ -4,6 +4,7 @@
                [clara.rules :refer [fire-rules
                                     insert
                                     insert-all
+                                    insert-unconditional!
                                     insert!
                                     retract
                                     query]]
@@ -165,3 +166,23 @@
              (query cold-query))
          [{:?t nil}])
       "Validate that :exists can match under a boolean :and condition."))
+
+;; Test of the performance optimization in https://github.com/cerner/clara-rules/issues/298
+;; The idea is that if inserting additional items beyond the first causes a retraction and then
+;; rebuilding of the Rete network an unconditional insertion will happen twice.
+(def-rules-test test-additional-item-noop
+
+  {:rules [exists-rule [[[:exists [Temperature (< temperature 0)]]]
+                         (insert-unconditional! (->Cold :freezing))]]
+
+   :queries [cold-query [[] [[Cold (= ?t temperature)]]]]
+
+   :sessions [empty-session [exists-rule cold-query] {}]}
+
+  (is (= [{:?t :freezing}]
+         (-> empty-session
+             (insert (->Temperature -10 "INV"))
+             (fire-rules)
+             (insert (->Temperature -10 "INV"))
+             fire-rules
+             (query cold-query)))))

--- a/src/test/common/clara/test_exists.cljc
+++ b/src/test/common/clara/test_exists.cljc
@@ -26,6 +26,7 @@
                                     insert
                                     insert!
                                     insert-all
+                                    insert-unconditional!
                                     retract
                                     query]]
                [clara.rules.testfacts :refer [->Temperature Temperature


### PR DESCRIPTION
… should not cause Rete operations

I added an explicit public exists accumulator - we'll want to support the :exists syntax in the DSL for backwards compatibility in any case, but are there thoughts on allowing users to use the accumulator directly?  Good or bad?  My instinct is that doing this without a DSL special case would have been preferable originally, and that having an accumulator that the docs can point to, even if using :exists, makes the behavior more transparent to users.  For example, since :exists is backed by an accumulator, it has all the characteristics of an accumulator condition around binding groups.  It would perhaps be possible to create an ExistsNode that is even more efficient than an accumulator if needed later, but I think we could detect that such a node could be used even if a Clara-supplied accumulator was given by the user via other checks - e.g. equality checks on the accumulator, metadata checks, etc.

@eraserhd this might be of interest to you from recent activity in the Slack channel as concerns the documentation aspects.