### PR TITLE
Issue 344: Add a function for reporting potential performance problem…

### DIFF
--- a/src/main/clojure/clara/tools/tracing.cljc
+++ b/src/main/clojure/clara/tools/tracing.cljc
@@ -114,3 +114,48 @@
                          (first))]
     (.-trace ^PersistentTracingListener listener)
     (throw (ex-info "No tracing listener attached to session." {:session session}))))
+
+(defn ^:private node-id->productions
+  "Given a session and a node ID return a list of the rule and query names associated
+   with the node."
+  [session id]
+  (let [node (-> session .-rulebase :id-to-node (get id))]
+    (into []
+          (comp
+           (map second)
+           cat
+           (map second))
+          (eng/get-conditions-and-rule-names node))))
+
+(defn traced-session->ranked-productions
+  "Given a session with tracing enabled, return a map of rule and query names
+  to a numerical index that represents an approximation of the proportional
+  amount of times Clara performed processing related to this rule.  This
+  is not intended to have a precise meaning, and is intended solely as a means
+  to provide a rough guide to which rules and queries should be considered
+  the first suspects when diagnosing  performance problems in rules sessions.
+  It is possible for a relatively small number of interactions to take a long
+  time if those interactions are particularly costly.  It is expected that
+  the results may change between different versions when Clara's internals change,
+  for example to optimize the rules network.  Nevertheless, it is anticipated
+  that this will provide useful information for a first pass at rules
+  performance problem debugging.  This should not be used to drive user logic.
+
+  This currently returns a Clojure array map currently in order to conveniently have the rules
+  with the most interactions printed first in the string representation of the map."
+  [session]
+  (let [node-ids (->> session
+                      get-trace
+                      (map :node-id))
+
+        production-names (into []
+                               (comp
+                                (map (partial node-id->productions session))
+                                cat)
+                               node-ids)
+
+        production-name->interactions (frequencies  production-names)
+
+        ranked-tuples (reverse (sort-by second production-name->interactions))]
+
+    (apply array-map (into [] cat ranked-tuples))))

--- a/src/main/clojure/clara/tools/tracing.cljc
+++ b/src/main/clojure/clara/tools/tracing.cljc
@@ -119,7 +119,7 @@
   "Given a session and a node ID return a list of the rule and query names associated
    with the node."
   [session id]
-  (let [node (-> session .-rulebase :id-to-node (get id))]
+  (let [node (-> session eng/components :rulebase :id-to-node (get id))]
     (into []
           (comp
            (map second)
@@ -127,7 +127,7 @@
            (map second))
           (eng/get-conditions-and-rule-names node))))
 
-(defn traced-session->ranked-productions
+(defn ranked-productions
   "Given a session with tracing enabled, return a map of rule and query names
   to a numerical index that represents an approximation of the proportional
   amount of times Clara performed processing related to this rule.  This
@@ -141,7 +141,7 @@
   that this will provide useful information for a first pass at rules
   performance problem debugging.  This should not be used to drive user logic.
 
-  This currently returns a Clojure array map currently in order to conveniently have the rules
+  This currently returns a Clojure array map in order to conveniently have the rules
   with the most interactions printed first in the string representation of the map."
   [session]
   (let [node-ids (->> session

--- a/src/test/common/clara/tools/test_tracing.cljc
+++ b/src/test/common/clara/tools/test_tracing.cljc
@@ -30,6 +30,7 @@
                                                ->TemperatureHistory TemperatureHistory
                                                ->Hot Hot
                                                ->Cold Cold
+                                               ->ColdAndWindy ColdAndWindy
                                                ->WindSpeed WindSpeed]])
       (:require-macros [clara.tools.testing-utils :refer [def-rules-test]]
                        [cljs.test :refer [is deftest run-tests testing use-fixtures]])))
@@ -157,3 +158,49 @@
    ;; Ensure only the expected fact was indicated as retracted.
    (let [retraction (first (filter #(= :retract-facts-logical (:type %)) session-trace))]
      (is (= [(->Cold 10)] (:facts retraction))))))
+
+(def-rules-test test-traced-session->ranked-productions
+  {:rules [temperature-rule [[[Temperature (= ?temperature temperature) (< temperature 20)]]
+                             (insert! (->Cold ?temperature))]
+
+           cold-and-windy-rule [[[ColdAndWindy (= ?temperature temperature) (< temperature 20)]]
+                                (insert! (->Cold ?temperature))]]
+
+   :sessions [empty-session [temperature-rule cold-and-windy-rule] {}]}
+
+  (let [mostly-temp (-> empty-session
+                        t/with-tracing
+                        (insert (->Temperature 10 "MCI"))
+                        fire-rules
+                        (insert (->Temperature 10 "MCI"))
+                        fire-rules
+                        (insert (->ColdAndWindy 10 10))
+                        fire-rules)
+
+        mostly-temp-counts (t/traced-session->ranked-productions mostly-temp)
+
+        mostly-cold-and-windy (-> empty-session
+                                  t/with-tracing
+                                  (insert (->Temperature 10 "MCI"))
+                                  fire-rules
+                                  (insert (->ColdAndWindy 10 10))
+                                  fire-rules
+                                  (insert (->ColdAndWindy 10 10))
+                                  fire-rules)
+
+        mostly-cold-and-windy-counts (t/traced-session->ranked-productions mostly-cold-and-windy)]
+
+    (is (= (keys mostly-temp-counts)
+           ["temperature-rule" "cold-and-windy-rule"]))
+
+    (is (= (keys mostly-cold-and-windy-counts)
+           ["cold-and-windy-rule" "temperature-rule"]))
+
+    ;; Since the exact number of interactions is subject to change based on Clara's internal implementation details
+    ;; we instead test the ratio of interaction counts instead, which should be more stable.  The pattern above
+    ;; of inserting and firing a single fact at a time prevents fact batching from impacting these ratios.
+    (is (= (mostly-temp-counts "temperature-rule")
+           (* 2 (mostly-temp-counts "cold-and-windy-rule"))))
+
+    (is  (= (mostly-cold-and-windy-counts "cold-and-windy-rule")
+            (* 2 (mostly-cold-and-windy-counts "temperature-rule"))))))

--- a/src/test/common/clara/tools/test_tracing.cljc
+++ b/src/test/common/clara/tools/test_tracing.cljc
@@ -159,7 +159,7 @@
    (let [retraction (first (filter #(= :retract-facts-logical (:type %)) session-trace))]
      (is (= [(->Cold 10)] (:facts retraction))))))
 
-(def-rules-test test-traced-session->ranked-productions
+(def-rules-test test-ranked-productions
   {:rules [temperature-rule [[[Temperature (= ?temperature temperature) (< temperature 20)]]
                              (insert! (->Cold ?temperature))]
 
@@ -177,7 +177,7 @@
                         (insert (->ColdAndWindy 10 10))
                         fire-rules)
 
-        mostly-temp-counts (t/traced-session->ranked-productions mostly-temp)
+        mostly-temp-counts (t/ranked-productions mostly-temp)
 
         mostly-cold-and-windy (-> empty-session
                                   t/with-tracing
@@ -188,7 +188,7 @@
                                   (insert (->ColdAndWindy 10 10))
                                   fire-rules)
 
-        mostly-cold-and-windy-counts (t/traced-session->ranked-productions mostly-cold-and-windy)]
+        mostly-cold-and-windy-counts (t/ranked-productions mostly-cold-and-windy)]
 
     (is (= (keys mostly-temp-counts)
            ["temperature-rule" "cold-and-windy-rule"]))


### PR DESCRIPTION
…s in a traced session

Pull request for [issue 344](https://github.com/cerner/clara-rules/issues/344)
@mrrodriguez this is one of the tracing helpers we've discussed before.

@EthanEChristian this is probably of interest to you.  Possibly @eraserhd as well if I recall some discussions on the Slack channel in recent months correctly.

Some remaining items to address:
- How does this handle nodes with more than one descendant terminal node?  I'd like to add tests for this.
- This will report autogenerated rules created from the extraction added to fix https://github.com/cerner/clara-rules/issues/149 . This is an existing issue with session inspection as well though - I don't think addressing this needs to block a merge.