### PR TITLE
#419: [Durability] Increased memory usage post Serde.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ This is a history of changes to clara-rules.
 # 0.20.0-SNAPSHOT
 * Added a new field to the clara.rules.engine/Accumulator record.  This could be a breaking change for any user durability implementations with low-level performance optimizations.  See [PR 410](https://github.com/cerner/clara-rules/pull/410) for details.
 * Performance improvements for :exists conditions.  See [issue 298](https://github.com/cerner/clara-rules/issues/298).
+* Decrease memory usage post deserialization (Durability). See [Issue 419](https://github.com/cerner/clara-rules/issues/419)
 
 ### 0.19.0
 * Remove a warning about `qualified-keyword?` being replaced when using Clojure 1.9.

--- a/src/main/clojure/clara/rules/durability.clj
+++ b/src/main/clojure/clara/rules/durability.clj
@@ -72,48 +72,48 @@
     (vswap! (.get node-id->node-cache) assoc node-id node))
   node)
 
-(def ^:internal ^ThreadLocal clj-record-holder
+(def ^:internal ^ThreadLocal clj-struct-holder
   "A cache for writing and reading Clojure records.  At write time, an IdentityHashMap can be
-   used to keep track of repeated references to the same record object instance occurring in
+   used to keep track of repeated references to the same object instance occurring in
    the serialization stream.  At read time, a plain ArrayList (mutable and indexed for speed)
    can be used to add records to when they are first seen, then look up repeated occurrences
    of references to the same record instance later."
   (ThreadLocal.))
 
-(defn clj-record-fact->idx
-  "Gets the numeric index for the given fact from the clj-record-holder."
+(defn clj-struct->idx
+  "Gets the numeric index for the given struct from the clj-struct-holder."
   [fact]
-  (-> clj-record-holder
+  (-> clj-struct-holder
     ^Map (.get)
     (.get fact)))
 
-(defn clj-record-holder-add-fact-idx!
-  "Adds the fact to the clj-record-holder with a new index.  This can later be retrieved
-   with clj-record-fact->idx."
+(defn clj-struct-holder-add-fact-idx!
+  "Adds the fact to the clj-struct-holder with a new index.  This can later be retrieved
+   with clj-struct->idx."
   [fact]
   ;; Note the values will be int type here.  This shouldn't be a problem since they
   ;; will be read later as longs and both will be compatible with the index lookup
   ;; at read-time.  This could have a cast to long here, but it would waste time
   ;; unnecessarily.
-  (-> clj-record-holder
+  (-> clj-struct-holder
     ^Map (.get)
-    (.put fact (-> clj-record-holder
+    (.put fact (-> clj-struct-holder
                  ^Map (.get)
                  (.size)))))
 
-(defn clj-record-idx->fact
-  "The reverse of clj-record-fact->idx.  Returns a fact for the given index found
-   in clj-record-holder."
+(defn clj-struct-idx->obj
+  "The reverse of clj-struct->idx.  Returns an object for the given index found
+   in clj-struct-holder."
   [id]
-  (-> clj-record-holder
+  (-> clj-struct-holder
     ^List (.get)
     (.get id)))
 
-(defn clj-record-holder-add-fact!
-  "The reverse of clj-record-holder-add-fact-idx!.  Adds the fact to the clj-record-holder
+(defn clj-struct-holder-add-obj!
+  "The reverse of clj-struct-holder-add-fact-idx!.  Adds the object to the clj-struct-holder
    at the next available index."
   [fact]
-  (-> clj-record-holder
+  (-> clj-struct-holder
     ^List (.get)
     (.add fact))
   fact)

--- a/src/main/clojure/clara/rules/durability/fressian.clj
+++ b/src/main/clojure/clara/rules/durability/fressian.clj
@@ -191,6 +191,40 @@
                       (read-record add-node-expr-fn)
                       d/cache-node)))}}))
 
+(defn- create-identity-based-handler
+  [clazz
+   tag
+   read-fn
+   write-fn]
+  (let [indexed-tag (str tag "idx")]
+    ;; Write an object a single time per object reference to that record.  The object is then "cached"
+    ;; with the IdentityHashMap `d/clj-struct-holder`.  If another reference to this object instance
+    ;; is encountered later, only the "index" of the object in the map will be written.
+    {:class clazz
+     :writer (reify WriteHandler
+               (write [_ w o]
+                 (if-let [idx (d/clj-struct->idx o)]
+                   (do
+                     (.writeTag w indexed-tag 1)
+                     (.writeInt w idx))
+                   (do
+                     (write-fn w tag o)
+                     (d/clj-struct-holder-add-fact-idx! o)))))
+     ;; When reading the first time a reference to an object instance is found, the entire object will
+     ;; need to be constructed.  It is then put into indexed cache.  If more references to this object
+     ;; instance are encountered later, they will be in the form of a numeric index into this cache.
+     ;; This is guaranteed by the semantics of the corresponding WriteHandler.
+     :readers {indexed-tag
+               (reify ReadHandler
+                 (read [_ rdr _ _]
+                   (d/clj-struct-idx->obj (.readInt rdr))))
+               tag
+               (reify ReadHandler
+                 (read [_ rdr _ _]
+                   (-> rdr
+                       read-fn
+                       d/clj-struct-holder-add-obj!)))}}))
+
 (def handlers
   "A structure tying together the custom Fressian write and read handlers used
    by FressianSessionSerializer's."
@@ -206,36 +240,29 @@
                   (resolve (.readObject rdr))))}}
 
    "clj/set"
-   {:class clojure.lang.APersistentSet
-    :writer (reify WriteHandler
-              (write [_ w o]
-                (write-with-meta w "clj/set" o)))
-    :readers {"clj/set"
-              (reify ReadHandler
-                (read [_ rdr tag component-count]
-                  (read-with-meta rdr set)))}}
+   (create-identity-based-handler
+     clojure.lang.APersistentSet
+     "clj/set"
+     (fn clj-set-reader [rdr] (read-with-meta rdr set))
+     write-with-meta)
 
    "clj/vector"
-   {:class clojure.lang.APersistentVector
-    :writer (reify WriteHandler
-              (write [_ w o]
-                (write-with-meta w "clj/vector" o)))
-    :readers {"clj/vector"
-              (reify ReadHandler
-                (read [_ rdr tag component-count]
-                  (read-with-meta rdr vec)))}}
+   (create-identity-based-handler
+     clojure.lang.APersistentVector
+     "clj/vector"
+     (fn clj-vec-reader [rdr] (read-with-meta rdr vec))
+     write-with-meta)
 
    "clj/list"
-   {:class clojure.lang.PersistentList
-    :writer (reify WriteHandler
-              (write [_ w o]
-                (write-with-meta w "clj/list" o)))
-    :readers {"clj/list"
-              (reify ReadHandler
-                (read [_ rdr tag component-count]
-                  (read-with-meta rdr #(apply list %))))}}
+   (create-identity-based-handler
+     clojure.lang.PersistentList
+     "clj/list"
+     (fn clj-list-reader [rdr] (read-with-meta rdr #(apply list %)))
+     write-with-meta)
 
    "clj/emptylist"
+   ;; Not using the identity based handler as this will always be identical anyway
+   ;; then meta data will be appended in the reader
    {:class clojure.lang.PersistentList$EmptyList
     :writer (reify WriteHandler
               (write [_ w o]
@@ -253,147 +280,112 @@
                             m (with-meta m)))))}}
 
    "clj/aseq"
-   {:class clojure.lang.ASeq
-    :writer (reify WriteHandler
-              (write [_ w o]
-                (write-with-meta w "clj/aseq" o)))
-    :readers {"clj/aseq"
-              (reify ReadHandler
-                (read [_ rdr tag component-count]
-                  (read-with-meta rdr sequence)))}}
+   (create-identity-based-handler
+     clojure.lang.ASeq
+     "clj/aseq"
+     (fn clj-seq-reader [rdr] (read-with-meta rdr sequence))
+     write-with-meta)
 
    "clj/lazyseq"
-   {:class clojure.lang.LazySeq
-    :writer (reify WriteHandler
-              (write [_ w o]
-                (write-with-meta w "clj/lazyseq" o)))
-    :readers {"clj/lazyseq"
-              (reify ReadHandler
-                (read [_ rdr tag component-count]
-                  (read-with-meta rdr sequence)))}}
+   (create-identity-based-handler
+     clojure.lang.LazySeq
+     "clj/lazyseq"
+     (fn clj-lazy-seq-reader [rdr] (read-with-meta rdr sequence))
+     write-with-meta)
 
    "clj/map"
-   {:class clojure.lang.APersistentMap
-    :writer (reify WriteHandler
-              (write [_ w o]
-                (write-with-meta w "clj/map" o write-map)))
-    :readers {"clj/map"
-              (reify ReadHandler
-                (read [_ rdr tag component-count]
-                  (read-with-meta rdr #(into {} %))))}}
+   (create-identity-based-handler
+     clojure.lang.APersistentMap
+     "clj/map"
+     (fn clj-map-reader [rdr] (read-with-meta rdr #(into {} %)))
+     (fn clj-map-writer [wtr tag m] (write-with-meta wtr tag m write-map)))
 
    "clj/treeset"
-   {:class clojure.lang.PersistentTreeSet
-    :writer (reify WriteHandler
-              (write [_ w o]
-                (let [cname (d/sorted-comparator-name o)]
-                  (.writeTag w "clj/treeset" 3)
-                  (if cname
-                    (.writeObject w cname true)
-                    (.writeNull w))
-                  ;; Preserve metadata.
-                  (if-let [m (meta o)]
-                    (.writeObject w m)
-                    (.writeNull w))
-                  (.writeList w o))))
-    :readers {"clj/treeset"
-              (reify ReadHandler
-                (read [_ rdr tag component-count]
-                  (let [c (some-> rdr .readObject resolve deref)
-                        m (.readObject rdr)
-                        s (-> (.readObject rdr)
-                              (d/seq->sorted-set c))]
-                    (if m
-                      (with-meta s m)
-                      s))))}}
+   (create-identity-based-handler
+     clojure.lang.PersistentTreeSet
+     "clj/treeset"
+     (fn clj-treeset-reader [^Reader rdr]
+       (let [c (some-> rdr .readObject resolve deref)
+             m (.readObject rdr)
+             s (-> (.readObject rdr)
+                   (d/seq->sorted-set c))]
+         (if m
+           (with-meta s m)
+           s)))
+     (fn clj-treeset-writer [^Writer wtr tag s]
+       (let [cname (d/sorted-comparator-name s)]
+         (.writeTag wtr tag 3)
+         (if cname
+           (.writeObject wtr cname true)
+           (.writeNull wtr))
+         ;; Preserve metadata.
+         (if-let [m (meta s)]
+           (.writeObject wtr m)
+           (.writeNull wtr))
+         (.writeList wtr s))))
 
    "clj/treemap"
-   {:class clojure.lang.PersistentTreeMap
-    :writer (reify WriteHandler
-              (write [_ w o]
-                (let [cname (d/sorted-comparator-name o)]
-                  (.writeTag w "clj/treemap" 3)
-                  (if cname
-                    (.writeObject w cname true)
-                    (.writeNull w))
-                  ;; Preserve metadata.
-                  (if-let [m (meta o)]
-                    (.writeObject w m)
-                    (.writeNull w))
-                  (write-map w o))))
-    :readers {"clj/treemap"
-              (reify ReadHandler
-                (read [_ rdr tag component-count]
-                  (let [c (some-> rdr .readObject resolve deref)
-                        m (.readObject rdr)
-                        s (d/seq->sorted-map (.readObject rdr) c)]
-                    (if m
-                      (with-meta s m)
-                      s))))}}
+   (create-identity-based-handler
+     clojure.lang.PersistentTreeMap
+     "clj/treemap"
+     (fn clj-treemap-reader [^Reader rdr]
+       (let [c (some-> rdr .readObject resolve deref)
+             m (.readObject rdr)
+             s (d/seq->sorted-map (.readObject rdr) c)]
+         (if m
+           (with-meta s m)
+           s)))
+     (fn clj-treemap-writer [^Writer wtr tag o]
+       (let [cname (d/sorted-comparator-name o)]
+         (.writeTag wtr tag 3)
+         (if cname
+           (.writeObject wtr cname true)
+           (.writeNull wtr))
+         ;; Preserve metadata.
+         (if-let [m (meta o)]
+           (.writeObject wtr m)
+           (.writeNull wtr))
+         (write-map wtr o))))
 
    "clj/mapentry"
-   {:class clojure.lang.MapEntry
-    :writer (reify WriteHandler
-              (write [_ w o]
-                (.writeTag w "clj/mapentry" 2)
-                (.writeObject w (key o) true)
-                (.writeObject w (val o))))
-    :readers {"clj/mapentry"
-              (reify ReadHandler
-                (read [_ rdr tag component-count]
-                  (d/create-map-entry (.readObject rdr)
-                                      (.readObject rdr))))}}
+   (create-identity-based-handler
+     clojure.lang.MapEntry
+     "clj/mapentry"
+     (fn clj-mapentry-reader [^Reader rdr]
+       (d/create-map-entry (.readObject rdr)
+                           (.readObject rdr)))
+     (fn clj-mapentry-writer [^Writer wtr tag o]
+       (.writeTag wtr tag 2)
+       (.writeObject wtr (key o) true)
+       (.writeObject wtr (val o))))
 
    ;; Have to redefine both Symbol and IRecord to support metadata as well
    ;; as identity-based caching for the IRecord case.
 
    "clj/sym"
-   {:class clojure.lang.Symbol
-    :writer (reify WriteHandler
-              (write [_ w o]
-                ;; Mostly copied from private fres/write-named, except the metadata part.
-                (.writeTag w "clj/sym" 3)
-                (.writeObject w (namespace o) true)
-                (.writeObject w (name o) true)
-                (if-let [m (meta o)]
-                  (.writeObject w m)
-                  (.writeNull w))))
-    :readers {"clj/sym"
-              (reify ReadHandler
-                (read [_ rdr tag component-count]
-                  (let [s (symbol (.readObject rdr) (.readObject rdr))
-                        m (read-meta rdr)]
-                    (cond-> s
-                            m (with-meta m)))))}}
+   (create-identity-based-handler
+     clojure.lang.Symbol
+     "clj/sym"
+     (fn clj-sym-reader [^Reader rdr]
+       (let [s (symbol (.readObject rdr) (.readObject rdr))
+             m (read-meta rdr)]
+         (cond-> s
+                 m (with-meta m))))
+     (fn clj-sym-writer [^Writer wtr tag o]
+       ;; Mostly copied from private fres/write-named, except the metadata part.
+       (.writeTag wtr tag 3)
+       (.writeObject wtr (namespace o) true)
+       (.writeObject wtr (name o) true)
+       (if-let [m (meta o)]
+         (.writeObject wtr m)
+         (.writeNull wtr))))
 
    "clj/record"
-   {:class clojure.lang.IRecord
-    ;; Write a record a single time per object reference to that record.  The record is then "cached"
-    ;; with the IdentityHashMap `d/clj-record-holder`.  If another reference to this record instance
-    ;; is encountered later, only the "index" of the record in the map will be written.
-    :writer (reify WriteHandler
-              (write [_ w rec]
-                (if-let [idx (d/clj-record-fact->idx rec)]
-                  (do
-                    (.writeTag w "clj/recordidx" 1)
-                    (.writeInt w idx))
-                  (do
-                    (write-record w "clj/record" rec)
-                    (d/clj-record-holder-add-fact-idx! rec)))))
-    ;; When reading the first time a reference to a record instance is found, the entire record will
-    ;; need to be constructed.  It is then put into indexed cache.  If more references to this record
-    ;; instance are encountered later, they will be in the form of a numeric index into this cache.
-    ;; This is guaranteed by the semantics of the corresponding WriteHandler.
-    :readers {"clj/recordidx"
-              (reify ReadHandler
-                (read [_ rdr tag component-count]
-                  (d/clj-record-idx->fact (.readInt rdr))))
-              "clj/record"
-              (reify ReadHandler
-                (read [_ rdr tag component-count]
-                  (-> rdr
-                      read-record
-                      d/clj-record-holder-add-fact!)))}}
+   (create-identity-based-handler
+     clojure.lang.IRecord
+     "clj/record"
+     read-record
+     write-record)
 
    "clara/productionnode"
    (create-cached-node-handler ProductionNode
@@ -548,7 +540,7 @@
             (with-open [^FressianWriter wtr
                         (fres/create-writer out-stream :handlers write-handler-lookup)]
               (pform/thread-local-binding [d/node-id->node-cache (volatile! {})
-                                           d/clj-record-holder record-holder]
+                                           d/clj-struct-holder record-holder]
                                           (doseq [s sources] (fres/write-object wtr s)))))]
       
       ;; In this case there is nothing to do with memory, so just serialize immediately.
@@ -597,7 +589,7 @@
                        maybe-base-rulebase
                        (let [without-opts-rulebase
                              (pform/thread-local-binding [d/node-id->node-cache (volatile! {})
-                                                          d/clj-record-holder record-holder]
+                                                          d/clj-struct-holder record-holder]
                                                          (pform/thread-local-binding [d/node-fn-cache (-> (fres/read-object rdr)
                                                                                                           reconstruct-expressions
                                                                                                           (com/compile-exprs forms-per-eval))]
@@ -609,7 +601,7 @@
         (if rulebase-only?
           rulebase
           (d/assemble-restored-session rulebase
-                                       (pform/thread-local-binding [d/clj-record-holder record-holder
+                                       (pform/thread-local-binding [d/clj-struct-holder record-holder
                                                                     d/mem-facts mem-facts]
                                                                    ;; internal memory contains facts provided by mem-facts
                                                                    ;; thus mem-facts must be bound before the call to read

--- a/src/main/clojure/clara/rules/durability/fressian.clj
+++ b/src/main/clojure/clara/rules/durability/fressian.clj
@@ -196,8 +196,8 @@
    tag
    read-fn
    write-fn]
-  (let [indexed-tag (str tag "idx")]
-    ;; Write an object a single time per object reference to that record.  The object is then "cached"
+  (let [indexed-tag (str tag "-idx")]
+    ;; Write an object a single time per object reference to that object.  The object is then "cached"
     ;; with the IdentityHashMap `d/clj-struct-holder`.  If another reference to this object instance
     ;; is encountered later, only the "index" of the object in the map will be written.
     {:class clazz

--- a/src/test/clojure/clara/test_fressian.clj
+++ b/src/test/clojure/clara/test_fressian.clj
@@ -18,11 +18,11 @@
               ^FressianWriter wtr (fres/create-writer os :handlers df/write-handler-lookup)]
     ;; Write
     (pform/thread-local-binding [d/node-id->node-cache (volatile! {})
-                                 d/clj-record-holder (java.util.IdentityHashMap.)]
+                                 d/clj-struct-holder (java.util.IdentityHashMap.)]
                                 (fres/write-object wtr x))
     ;; Read
     (let [data (.toByteArray os)]
-      (pform/thread-local-binding [d/clj-record-holder (java.util.ArrayList.)]
+      (pform/thread-local-binding [d/clj-struct-holder (java.util.ArrayList.)]
                                   (with-open [is (java.io.ByteArrayInputStream. data)
                                               ^FressianReader rdr (fres/create-reader is :handlers df/read-handler-lookup)]
                                     (fres/read-object rdr))))))
@@ -107,4 +107,15 @@
         (is (thrown? Exception
                      (serde (with-meta sm-custom {})))
             "cannot serialized custom sort comparators without name given in metadata")))))
+
+(deftest test-handler-identity
+  (let [v [1 2 3]
+        l (list 4 5 6)
+        m {:a 1 :b 2}
+        s #{:a :b :c}
+        r (serde (->Tester [v v l l m m s s]))]
+    (doseq [[x y] (partition 2 (:x r))]
+      (testing (str "Serde preserves identity for " (type x))
+        (is (identical? x y)
+            "preserving object references")))))
 

--- a/src/test/clojure/clara/test_fressian.clj
+++ b/src/test/clojure/clara/test_fressian.clj
@@ -111,9 +111,13 @@
 (deftest test-handler-identity
   (let [v [1 2 3]
         l (list 4 5 6)
+        ls (map inc [1 2 3])
         m {:a 1 :b 2}
         s #{:a :b :c}
-        r (serde (->Tester [v v l l m m s s]))]
+        sym 'a
+        os (sorted-set "a" "c" "b")
+        om (sorted-map "a" 1 "c" 3 "b" 2)
+        r (serde (->Tester [v v l l ls ls m m s s sym sym os os om om]))]
     (doseq [[x y] (partition 2 (:x r))]
       (testing (str "Serde preserves identity for " (type x))
         (is (identical? x y)


### PR DESCRIPTION
I think this is the easiest solution for #419.

Comparing the Heap dumps provided on the original issue, the heap dumps now look like:
Pre-Serialization:
<img width="1123" alt="new_clara_local_session_pre-serialization" src="https://user-images.githubusercontent.com/3660185/52365365-ef0b9a80-2a0c-11e9-8acb-a931ea1daa42.png">
Post-Serialization:
<img width="1129" alt="new_clara_local_session_post-serialization" src="https://user-images.githubusercontent.com/3660185/52365393-ff237a00-2a0c-11e9-850b-edd2c1ed17b3.png">

While I would like to see the after heap usage closer to that of the before, i believe that Will's [comment](https://github.com/cerner/clara-rules/issues/419#issuecomment-460848471) explains why this is unlikely possible.

Running the Compilation/Serialization performance tests:
Before:
![lein_performance_tests_before](https://user-images.githubusercontent.com/3660185/52365795-e36ca380-2a0d-11e9-8c26-77e17afc9e7c.png)

After:
![lein_performance_tests_after](https://user-images.githubusercontent.com/3660185/52365801-e798c100-2a0d-11e9-9781-0cc408a5777f.png)


Another thing to note is that prior to these changes the Session took up ~137MB on disk and after it was ~62.4MB. (This metric applies to the Heap dumps above, not the performance tests.)

@WilliamParker  @mrrodriguez 