### PR TITLE
#422: Expose flag to retain compile-ctx instead of maintaining it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 This is a history of changes to clara-rules.
 
+# 0.20.0 SNAPSHOT
+* Add flag to omit compilation context after Session compilation for use in serialization and deserialization. [issue 422](https://github.com/cerner/clara-rules/issues/422)
+
 # 0.19.1
 * Added a new field to the clara.rules.engine/Accumulator record.  This could be a breaking change for any user durability implementations with low-level performance optimizations.  See [PR 410](https://github.com/cerner/clara-rules/pull/410) for details.
 * Performance improvements for :exists conditions.  See [issue 298](https://github.com/cerner/clara-rules/issues/298).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 This is a history of changes to clara-rules.
 
 # 0.20.0 SNAPSHOT
-* Add flag to omit compilation context after Session compilation for use in serialization and deserialization. [issue 422](https://github.com/cerner/clara-rules/issues/422)
+* Add a flag to omit compilation context (used by the durability layer) after Session compilation to save space when not needed. Defaults to true. [issue 422](https://github.com/cerner/clara-rules/issues/422)
 
 # 0.19.1
 * Added a new field to the clara.rules.engine/Accumulator record.  This could be a breaking change for any user durability implementations with low-level performance optimizations.  See [PR 410](https://github.com/cerner/clara-rules/pull/410) for details.

--- a/src/main/clojure/clara/rules.cljc
+++ b/src/main/clojure/clara/rules.cljc
@@ -332,6 +332,8 @@
       * :forms-per-eval - The maximum number of expressions that will be evaluated per call to eval.
         Larger batch sizes should see better performance compared to smaller batch sizes. (Only applicable to Clojure)
         Defaults to 5000, see clara.rules.compiler/forms-per-eval-default for more information.
+      * :retain-compile-ctx - Retain compilation information for better compilation failures.
+        Defaults to false, see clara.rules.compiler/retain-compile-ctx-default for more information.
 
       This is not supported in ClojureScript, since it requires eval to dynamically build a session. ClojureScript
       users must use pre-defined rule sessions using defsession."

--- a/src/main/clojure/clara/rules.cljc
+++ b/src/main/clojure/clara/rules.cljc
@@ -332,8 +332,12 @@
       * :forms-per-eval - The maximum number of expressions that will be evaluated per call to eval.
         Larger batch sizes should see better performance compared to smaller batch sizes. (Only applicable to Clojure)
         Defaults to 5000, see clara.rules.compiler/forms-per-eval-default for more information.
-      * :retain-compile-ctx - Retain compilation information for better compilation failures.
-        Defaults to false, see clara.rules.compiler/retain-compile-ctx-default for more information.
+      * :omit-compile-ctx - When false Clara, in Clojure, retains additional information to improve error messages during
+        session deserialization at the cost of additional memory use.
+        By default this information is retained till the session is initially compiled and then will be discarded,
+        in the event that the Session will be serialized and deserialized (Durability) this information could be useful
+        if the session could not be compiled properly.
+        Defaults to true, see clara.rules.compiler/omit-compile-ctx-default for more information.
 
       This is not supported in ClojureScript, since it requires eval to dynamically build a session. ClojureScript
       users must use pre-defined rule sessions using defsession."

--- a/src/main/clojure/clara/rules.cljc
+++ b/src/main/clojure/clara/rules.cljc
@@ -334,9 +334,9 @@
         Defaults to 5000, see clara.rules.compiler/forms-per-eval-default for more information.
       * :omit-compile-ctx - When false Clara, in Clojure, retains additional information to improve error messages during
         session deserialization at the cost of additional memory use.
-        By default this information is retained till the session is initially compiled and then will be discarded,
-        in the event that the Session will be serialized and deserialized (Durability) this information could be useful
-        if the session could not be compiled properly.
+        By default this information is retained until the session is initially compiled and then will be discarded. This
+        information might prove useful for debugging compilation errors within the rulebase, eg. rulebase serialization
+        (ie. via Clara's durability support).
         Defaults to true, see clara.rules.compiler/omit-compile-ctx-default for more information.
 
       This is not supported in ClojureScript, since it requires eval to dynamically build a session. ClojureScript

--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -1966,8 +1966,11 @@
         retain-compile-ctx (:retain-compile-ctx options retain-compile-ctx-default)
         exprs (if retain-compile-ctx
                 exprs
-                (zipmap (keys exprs)
-                        (mapv (juxt first #(dissoc (second %) :compile-ctx)) (vals exprs))))
+                (into {}
+                      (map
+                        (fn [[k [expr ctx]]]
+                          [k [expr (dissoc ctx :compile-ctx)]]))
+                      exprs))
 
         beta-tree (compile-beta-graph beta-graph exprs)
         beta-root-ids (-> beta-graph :forward-edges (get 0)) ; 0 is the id of the virtual root node.

--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -1964,13 +1964,13 @@
         ;; uncertain deserialization environment and this sort of troubleshooting information would be useful
         ;; in diagnosing compilation errors in specific rules.
         omit-compile-ctx (:omit-compile-ctx options omit-compile-ctx-default)
-        exprs (if-not omit-compile-ctx
-                exprs
+        exprs (if omit-compile-ctx
                 (into {}
                       (map
                         (fn [[k [expr ctx]]]
                           [k [expr (dissoc ctx :compile-ctx)]]))
-                      exprs))
+                      exprs)
+                exprs)
 
         beta-tree (compile-beta-graph beta-graph exprs)
         beta-root-ids (-> beta-graph :forward-edges (get 0)) ; 0 is the id of the virtual root node.

--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -1917,14 +1917,14 @@
    This sums to 65,527B just shy of the 65,536B method size limit."
   5000)
 
-(def retain-compile-ctx-default
+(def omit-compile-ctx-default
   "During construction of the Session there is data maintained such that if the underlying expressions fail to compile
-   then this data can be used to explain the failure and the constraints of the rule whos expression is being evaluated.
+   then this data can be used to explain the failure and the constraints of the rule who's expression is being evaluated.
    The default behavior will be to discard this data, as there will be no use unless the session will be serialized and
    deserialized into a dissimilar environment, ie function or symbols might be unresolvable. In those sorts of scenarios
-   it would be possible to construct the original Session with the `retain-compile-ctx` flag set to true, then the compile
+   it would be possible to construct the original Session with the `omit-compile-ctx` flag set to false, then the compile
    context should aid in debugging the compilation failure on deserialization."
-  false)
+  true)
 
 (sc/defn mk-session*
   "Compile the rules into a rete network and return the given session."
@@ -1958,13 +1958,13 @@
         ;; This is a performance optimization, see Issue 381 for more information.
         exprs (compile-exprs (extract-exprs beta-graph alpha-graph) forms-per-eval)
 
-        ;; If we have made it to this, it means that we have succeeded in compiling all expressions
+        ;; If we have made it to this point, it means that we have succeeded in compiling all expressions
         ;; thus we can free the :compile-ctx used for troubleshooting compilation failures.
         ;; The reason that this flag exists is in the event that this session will be serialized with an
         ;; uncertain deserialization environment and this sort of troubleshooting information would be useful
         ;; in diagnosing compilation errors in specific rules.
-        retain-compile-ctx (:retain-compile-ctx options retain-compile-ctx-default)
-        exprs (if retain-compile-ctx
+        omit-compile-ctx (:omit-compile-ctx options omit-compile-ctx-default)
+        exprs (if-not omit-compile-ctx
                 exprs
                 (into {}
                       (map

--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -1917,6 +1917,15 @@
    This sums to 65,527B just shy of the 65,536B method size limit."
   5000)
 
+(def retain-compile-ctx-default
+  "During construction of the Session there is data maintained such that if the underlying expressions fail to compile
+   then this data can be used to explain the failure and the constraints of the rule whos expression is being evaluated.
+   The default behavior will be to discard this data, as there will be no use unless the session will be serialized and
+   deserialized into a dissimilar environment, ie function or symbols might be unresolvable. In those sorts of scenarios
+   it would be possible to construct the original Session with the `retain-compile-ctx` flag set to true, then the compile
+   context should aid in debugging the compilation failure on deserialization."
+  false)
+
 (sc/defn mk-session*
   "Compile the rules into a rete network and return the given session."
   [productions :- #{schema/Production}
@@ -1948,6 +1957,18 @@
         ;; Extract the expressions from the graphs and evaluate them in a batch manner.
         ;; This is a performance optimization, see Issue 381 for more information.
         exprs (compile-exprs (extract-exprs beta-graph alpha-graph) forms-per-eval)
+
+        ;; If we have made it to this, it means that we have succeeded in compiling all expressions
+        ;; thus we can free the :compile-ctx used for troubleshooting compilation failures.
+        ;; The reason that this flag exists is in the event that this session will be serialized with an
+        ;; uncertain deserialization environment and this sort of troubleshooting information would be useful
+        ;; in diagnosing compilation errors in specific rules.
+        retain-compile-ctx (:retain-compile-ctx options retain-compile-ctx-default)
+        exprs (if retain-compile-ctx
+                exprs
+                (zipmap (keys exprs)
+                        (mapv (juxt first #(dissoc (second %) :compile-ctx)) (vals exprs))))
+
         beta-tree (compile-beta-graph beta-graph exprs)
         beta-root-ids (-> beta-graph :forward-edges (get 0)) ; 0 is the id of the virtual root node.
         beta-roots (vals (select-keys beta-tree beta-root-ids))

--- a/src/main/clojure/clara/rules/schema.cljc
+++ b/src/main/clojure/clara/rules/schema.cljc
@@ -167,7 +167,7 @@
                         (every? nil? (map s/check items tuple-vals))))
                  "tuple"))
 
-(def NodeComplilationValue
+(def NodeCompilationValue
   (s/constrained {s/Keyword s/Any}
                  (fn [compilation]
                    (let [expr-keys #{:alpha-expr :action-expr :join-filter-expr :test-expr :accum-expr}]
@@ -175,7 +175,7 @@
                  "node-compilation-value"))
 
 (def NodeCompilationContext
-  (s/constrained NodeComplilationValue
+  (s/constrained NodeCompilationValue
                  (fn [compilation]
                    (let [xor #(and (or %1 %2)
                                    (not (and %1 %2)))]
@@ -191,7 +191,7 @@
   ;; but during serde it might be either as :compile-ctx is only used for compilation failures
   ;; and can be disabled post compilation.
   {(tuple s/Int s/Keyword) (tuple SExpr (s/conditional :compile-ctx NodeCompilationContext
-                                                       :else NodeComplilationValue))})
+                                                       :else NodeCompilationValue))})
 
 ;; An evaluated version of the schema mentioned above.
 (def NodeFnLookup
@@ -200,4 +200,4 @@
   ;; deserialization. In such events the compile-ctx would only be valuable when the environment
   ;; where the Session is being deserialized doesn't match that of the serialization, ie functions
   ;; and symbols cannot be resolved on the deserialization side.
-  {(tuple s/Int s/Keyword) (tuple (s/pred ifn? "ifn?") NodeComplilationValue)})
+  {(tuple s/Int s/Keyword) (tuple (s/pred ifn? "ifn?") NodeCompilationValue)})

--- a/src/main/clojure/clara/rules/schema.cljc
+++ b/src/main/clojure/clara/rules/schema.cljc
@@ -167,23 +167,37 @@
                         (every? nil? (map s/check items tuple-vals))))
                  "tuple"))
 
-(def NodeCompilationContext
+(def NodeComplilationValue
   (s/constrained {s/Keyword s/Any}
-                 (fn [ctx]
-                   (let [expr-keys #{:alpha-expr :action-expr :join-filter-expr :test-expr :accum-expr}
-                         xor #(and (or %1 %2)
+                 (fn [compilation]
+                   (let [expr-keys #{:alpha-expr :action-expr :join-filter-expr :test-expr :accum-expr}]
+                     (some expr-keys (keys compilation))))
+                 "node-compilation-value"))
+
+(def NodeCompilationContext
+  (s/constrained NodeComplilationValue
+                 (fn [compilation]
+                   (let [xor #(and (or %1 %2)
                                    (not (and %1 %2)))]
-                     (and (some expr-keys (keys ctx))
-                          (contains? ctx :compile-ctx)
-                          (contains? (:compile-ctx ctx) :msg)
-                          (xor (contains? (:compile-ctx ctx) :condition)
-                               (contains? (:compile-ctx ctx) :production)))))
+                     (and (contains? compilation :compile-ctx)
+                          (contains? (:compile-ctx compilation) :msg)
+                          (xor (contains? (:compile-ctx compilation) :condition)
+                               (contains? (:compile-ctx compilation) :production)))))
                  "node-compilation-context"))
 
 ;; A map of [<node-id> <field-name>] to SExpression, used in compilation of the rulebase.
 (def NodeExprLookup
-  {(tuple s/Int s/Keyword) (tuple SExpr NodeCompilationContext)})
+  ;; schema should be NodeCompilationContext in standard compilation,
+  ;; but during serde it might be either as :compile-ctx is only used for compilation failures
+  ;; and can be disabled post compilation.
+  {(tuple s/Int s/Keyword) (tuple SExpr (s/conditional :compile-ctx NodeCompilationContext
+                                                       :else NodeComplilationValue))})
 
 ;; An evaluated version of the schema mentioned above.
 (def NodeFnLookup
-  {(tuple s/Int s/Keyword) (tuple (s/pred ifn? "ifn?") NodeCompilationContext)})
+  ;; This schema uses a relaxed version of NodeCompilationContext as once the expressions
+  ;; have been eval'd there is technically no need for compile-ctx to be maintained except for
+  ;; deserialization. In such events the compile-ctx would only be valuable when the environment
+  ;; where the Session is being deserialized doesn't match that of the serialization, ie functions
+  ;; and symbols cannot be resolved on the deserialization side.
+  {(tuple s/Int s/Keyword) (tuple (s/pred ifn? "ifn?") NodeComplilationValue)})

--- a/src/main/clojure/clara/tools/testing_utils.cljc
+++ b/src/main/clojure/clara/tools/testing_utils.cljc
@@ -152,3 +152,54 @@
         (str "Actual mean value: " mean))
     {:mean mean
      :std std}))
+
+#?(:clj
+   (defn ex-data-search [^Exception e edata]
+     (loop [non-matches []
+            e e]
+       (cond
+         ;; Found match.
+         (= edata
+            (select-keys (ex-data e)
+                         (keys edata)))
+         :success
+
+         ;; Keep searching, record any non-matching ex-data.
+         (.getCause e)
+         (recur (if-let [ed (ex-data e)]
+                  (conj non-matches ed)
+                  non-matches)
+                (.getCause e))
+
+         ;; Can't find a match.
+         :else
+         non-matches))))
+
+#?(:clj
+   (defn get-all-ex-data
+     "Walk a Throwable chain and return a sequence of all data maps
+  from any ExceptionInfo instances in that chain."
+     [e]
+     (let [get-ex-chain (fn get-ex-chain [e]
+                          (if-let [cause (.getCause e)]
+                            (conj (get-ex-chain cause) e)
+                            [e]))]
+
+       (map ex-data
+            (filter (partial instance? clojure.lang.IExceptionInfo)
+                    (get-ex-chain e))))))
+
+#?(:clj
+   (defmacro assert-ex-data [expected-ex-data form]
+     `(try
+        ~form
+        (is false
+            (str "Exception expected to be thrown when evaluating: " \newline
+                 '~form))
+        (catch Exception e#
+          (let [res# (ex-data-search e# ~expected-ex-data)]
+            (is (= :success res#)
+                (str "Exception msg found: " \newline
+                     e# \newline
+                     "Non matches found: " \newline
+                     res#)))))))


### PR DESCRIPTION
Using #420 's results as a baseline, meaning that these numbers include those changes as well, and using the same session. I was able to get a few heap dumps of the session without the `:compile-ctx` being stored.

Pre-serialization:
<img width="1127" alt="clara_pre-serde_sans_cc" src="https://user-images.githubusercontent.com/3660185/52424264-3eaa9e80-2abf-11e9-8235-2e750e4b9ee6.png">
Post-serialization:
<img width="1124" alt="clara_post-serde_sans_cc" src="https://user-images.githubusercontent.com/3660185/52424282-4a966080-2abf-11e9-8ed2-a1bdb8b476a2.png">

The thing to note here is that the pre-serialization, from my knowledge the standard use-case of clara, has dropped from ~523.6MB to ~504.0MB (again this is a Session containing 31k rules, so milage may vary).

The disk size of the Session also dropped from 62.4MB to 59.1MB.