### PR TITLE
Issue 275: Thow exception on infinite loops

### DIFF
--- a/src/main/clojure/clara/rules.cljc
+++ b/src/main/clojure/clara/rules.cljc
@@ -35,6 +35,12 @@
 
    This take an additional map of options as a second argument.  Current options:
 
+   :max-cycles (positive integer): Each time Clara determines that there are no more insertions process in a given activation group (rules with the same salience)
+    it records that one cycle of processing rules has been performed.  When the max-cycles limit is reached Clara throws an exception indicating that the rules
+    are in an infinite loop.  This exception can be regarded as analogous to a StackOverflowError.  The default is 600000, which is a level at which it is unlikely that
+    most users will encounter this error in cases where the rules actually would eventually terminate.  See issue 275 for details on how this level was chosen.
+    Nevertheless, it is possible that such cases exist, and so an option is provided to increase the limit.  Furthermore, some infinite loop scenarios will cause memory
+    errors before this ceiling is reached, and so users who do not expect to need a large number of rule cycles may wish to lower this limit.
    :cancelling true (EXPERIMENTAL, subject to change/removal.  Not supported in ClojureScript.):  
     Simultaneously propagate insertions and retractions through the rules network, at every step using the insertion and retractions of equals facts to cancel each
     other out and avoid operations deeper in the rules network.  The behavior of unconditional insertions and RHS (right-hand side) retractions

--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -1968,9 +1968,6 @@
         ;; where internal-salience is considered after the rule-salience and is assigned automatically by the compiler.
         activation-group-fn (eng/options->activation-group-fn options)
 
-        max-cycles (or (:max-cycles options)
-                       600000)
-
         rulebase (build-network beta-tree beta-roots alpha-nodes productions
                                 fact-type-fn ancestors-fn activation-group-sort-fn activation-group-fn
                                 exprs)
@@ -1983,8 +1980,7 @@
                    :memory (eng/local-memory rulebase transport activation-group-sort-fn activation-group-fn get-alphas-fn)
                    :transport transport
                    :listeners (get options :listeners  [])
-                   :get-alphas-fn get-alphas-fn
-                   :max-cycles max-cycles})))
+                   :get-alphas-fn get-alphas-fn})))
 
 (defn add-production-load-order
   "Adds ::rule-load-order to metadata of productions. Custom DSL's may need to use this if

--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -1968,6 +1968,9 @@
         ;; where internal-salience is considered after the rule-salience and is assigned automatically by the compiler.
         activation-group-fn (eng/options->activation-group-fn options)
 
+        max-cycles (or (:max-cycles options)
+                       600000)
+
         rulebase (build-network beta-tree beta-roots alpha-nodes productions
                                 fact-type-fn ancestors-fn activation-group-sort-fn activation-group-fn
                                 exprs)
@@ -1980,7 +1983,8 @@
                    :memory (eng/local-memory rulebase transport activation-group-sort-fn activation-group-fn get-alphas-fn)
                    :transport transport
                    :listeners (get options :listeners  [])
-                   :get-alphas-fn get-alphas-fn})))
+                   :get-alphas-fn get-alphas-fn
+                   :max-cycles max-cycles})))
 
 (defn add-production-load-order
   "Adds ::rule-load-order to metadata of productions. Custom DSL's may need to use this if

--- a/src/main/clojure/clara/tools/testing_utils.cljc
+++ b/src/main/clojure/clara/tools/testing_utils.cljc
@@ -152,3 +152,20 @@
         (str "Actual mean value: " mean))
     {:mean mean
      :std std}))
+
+#?(:clj
+   (defn ex-data-maps
+     "Given a Throwable, return in order the ExceptionInfo data maps for all items in the
+      chain that implement IExceptionInfo and have nonempty data maps."
+     [t]
+     (let [throwables  ((fn append-self
+                          [prior t1]
+                          (if t1
+                            (append-self (conj prior t1) (.getCause ^Throwable t1))
+                            prior))
+                        []
+                        t)]
+       (into []
+             (comp (map ex-data)
+                   (filter not-empty))
+             throwables))))

--- a/src/test/clojure/clara/test_infinite_loops.clj
+++ b/src/test/clojure/clara/test_infinite_loops.clj
@@ -1,0 +1,41 @@
+(ns clara.test-infinite-loops
+  (:require [clojure.test :refer :all]
+            [clara.rules :refer :all]
+            [clara.rules.testfacts :refer [->Cold  ->Hot]]
+            [clara.tools.testing-utils :refer [def-rules-test]]
+            [clara.test-rules :refer [assert-ex-data]])
+  (:import [clara.rules.testfacts Temperature WindSpeed Cold Hot TemperatureHistory
+            ColdAndWindy LousyWeather First Second Third Fourth FlexibleFields]))
+
+(def-rules-test test-simple-loop
+
+  {:rules [hot-rule [[[:not [Hot]]]
+                     (insert! (->Cold nil))]
+
+           cold-rule [[[Cold]]
+                      (insert! (->Hot nil))]]
+
+   :sessions [empty-session [hot-rule cold-rule] {:max-cycles 3000}]}
+
+  (assert-ex-data  {:clara-rules/infinite-loop-suspected true}  (fire-rules empty-session)))
+
+
+(def-rules-test test-recursive-insertion
+
+  {:rules [cold-rule [[[Cold]]
+                      (insert! (->Cold "ORD"))]]
+
+   ;; Use a small value here to ensure that we don't run out of memory before throwing.
+   ;; There is unfortunately a tradeoff where making the default number of cycles allowed
+   ;; high enough for some use cases will allow others to create OutOfMemory errors in cases
+   ;; like these but we can at least throw when there is enough memory available to hold the facts
+   ;; created in the loop.
+   :sessions [empty-session [cold-rule] {:max-cycles 10}]}
+
+  (assert-ex-data {:clara-rules/infinite-loop-suspected true}
+                  (-> empty-session
+                      (insert (->Cold "ARN"))
+                      fire-rules)))
+
+
+

--- a/src/test/clojure/clara/test_infinite_loops.clj
+++ b/src/test/clojure/clara/test_infinite_loops.clj
@@ -1,17 +1,24 @@
 (ns clara.test-infinite-loops
   (:require [clojure.test :refer :all]
             [clara.rules :refer :all]
-            [clara.rules.testfacts :refer [->Cold  ->Hot]]
+            [clara.rules.testfacts :refer [->Cold  ->Hot ->First ->Second]]
             [clara.tools.testing-utils :refer [def-rules-test
-                                               ex-data-maps]]
+                                               ex-data-maps
+                                               side-effect-holder-fixture
+                                               side-effect-holder]]
             [clara.test-rules :refer [assert-ex-data]]
-            [clara.tools.tracing :as tr])
-  (:import [clara.rules.testfacts Temperature WindSpeed Cold Hot TemperatureHistory
-            ColdAndWindy LousyWeather First Second Third Fourth FlexibleFields]
+            [clara.tools.tracing :as tr]
+            [clara.rules.accumulators :as acc])
+  (:import [clara.rules.testfacts Cold Hot First Second]
            [clara.tools.tracing
             PersistentTracingListener]))
 
-(def-rules-test test-simple-loop
+(use-fixtures :each side-effect-holder-fixture)
+
+(def-rules-test test-truth-maintenance-loop
+
+  ;; Test of an infinite loop to an endless cycle caused by truth maintenance,
+  ;; that is an insertion that causes its support to be retracted.
 
   {:rules [hot-rule [[[:not [Hot]]]
                      (insert! (->Cold nil))]
@@ -23,8 +30,33 @@
 
   (assert-ex-data  {:clara-rules/infinite-loop-suspected true}  (fire-rules empty-session {:max-cycles 3000})))
 
+(def-rules-test test-truth-maintenance-loop-with-salience
+
+  ;; Test of an infinite loop to an endless cycle caused by truth maintenance,
+  ;; that is an insertion that causes its support to be retracted, when the
+  ;; two rules that form the loop have salience and are thus parts of different
+  ;; activation groups.
+
+  
+  {:rules [hot-rule [[[:not [Hot]]]
+                     (insert! (->Cold nil))
+                     {:salience 1}]
+
+           cold-rule [[[Cold]]
+                      (insert! (->Hot nil))
+                      {:salience 2}]]
+
+   :sessions [empty-session [hot-rule cold-rule] {}
+              empty-session-negated-salience [hot-rule cold-rule] {:activation-group-fn (comp - :salience :props)}]}
+
+  (doseq [session [empty-session empty-session-negated-salience]]
+    ;; Validate that the results are the same in either rule ordering.
+    (assert-ex-data  {:clara-rules/infinite-loop-suspected true}  (fire-rules session {:max-cycles 3000}))))
+
 
 (def-rules-test test-recursive-insertion
+
+  ;; Test of an infinite loop due to runaway insertions without retractions.
 
   {:rules [cold-rule [[[Cold]]
                       (insert! (->Cold "ORD"))]]
@@ -40,6 +72,40 @@
                       ;; like these but we can at least throw when there is enough memory available to hold the facts
                       ;; created in the loop.
                       (fire-rules {:max-cycles 10}))))
+
+(def-rules-test test-recursive-insertion-loop-no-salience
+
+  {:rules [first-rule [[[First]]
+                       (insert! (->Second))]
+
+           second-rule [[[Second]]
+                        (insert! (->First))]]
+
+   :sessions [empty-session [first-rule second-rule] {}]}
+
+  (assert-ex-data {:clara-rules/infinite-loop-suspected true}
+                  (-> empty-session
+                      (insert (->First))
+                      (fire-rules {:max-cycles 10}))))
+
+(def-rules-test test-recursive-insertion-loop-with-salience
+
+  {:rules [first-rule [[[First]]
+                       (insert! (->Second))
+                       {:salience 1}]
+
+           second-rule [[[Second]]
+                        (insert! (->First))
+                        {:salience 2}]]
+
+   :sessions [empty-session [first-rule second-rule] {}
+              empty-session-negated-salience [first-rule second-rule] {:activation-group-fn (comp - :salience :props)}]}
+
+  (doseq [session [empty-session empty-session-negated-salience]]
+    (assert-ex-data {:clara-rules/infinite-loop-suspected true}
+                    (-> session
+                        (insert (->First))
+                        (fire-rules {:max-cycles 10})))))
 
 (def-rules-test test-tracing-infinite-loop
 
@@ -69,10 +135,39 @@
             "There should only be one listener.")
         (is (-> loop-data first  :listeners ^PersistentTracingListener first .-trace not-empty)
             "There should be tracing data available when a traced session throws an exception on an infinite loop.")))))
-            
-  
+
+(def-rules-test test-max-cycles-respected
+
+  ;; As the name suggests, this is a test to validate that setting the max-cycles to different
+  ;; values actually works.  The others tests are focused on validating that infinite loops
+  ;; throw exceptions, and the max-cycles values there are simply set to restrict resource usage,
+  ;; whether CPU or memory, by the test.  Here, on the other hand, we construct a rule where we control
+  ;; how many rule cycles will be executed, and then validate that an exception is thrown when that number is
+  ;; greater than the max-cycles and is not when it isn't.  For good measure, we validate that the non-exception-throwing
+  ;; case has queryable output to make sure that the logic was actually run, not ommitted because of a typo or similar.
+
+  {:rules [recursive-rule-with-end [[[First]]
+                                    (when (< @side-effect-holder 20)
+                                      (do
+                                        (insert-unconditional! (->First))
+                                        (swap! side-effect-holder inc)))]]
+
+   :queries [first-query [[] [[?f <- First]]]]
+
+   :sessions [empty-session [recursive-rule-with-end first-query] {}]}
 
 
+  (reset! side-effect-holder 0)
 
+  (assert-ex-data {:clara-rules/infinite-loop-suspected true}
+                  (-> empty-session
+                      (insert (->First))
+                      (fire-rules {:max-cycles 10})))
 
+  (reset! side-effect-holder 0)
 
+  (is (= (count (-> empty-session
+                    (insert (->First))
+                    (fire-rules {:max-cycles 30})
+                    (query first-query)))
+         21)))

--- a/src/test/clojure/clara/test_infinite_loops.clj
+++ b/src/test/clojure/clara/test_infinite_loops.clj
@@ -2,10 +2,14 @@
   (:require [clojure.test :refer :all]
             [clara.rules :refer :all]
             [clara.rules.testfacts :refer [->Cold  ->Hot]]
-            [clara.tools.testing-utils :refer [def-rules-test]]
-            [clara.test-rules :refer [assert-ex-data]])
+            [clara.tools.testing-utils :refer [def-rules-test
+                                               ex-data-maps]]
+            [clara.test-rules :refer [assert-ex-data]]
+            [clara.tools.tracing :as tr])
   (:import [clara.rules.testfacts Temperature WindSpeed Cold Hot TemperatureHistory
-            ColdAndWindy LousyWeather First Second Third Fourth FlexibleFields]))
+            ColdAndWindy LousyWeather First Second Third Fourth FlexibleFields]
+           [clara.tools.tracing
+            PersistentTracingListener]))
 
 (def-rules-test test-simple-loop
 
@@ -15,9 +19,9 @@
            cold-rule [[[Cold]]
                       (insert! (->Hot nil))]]
 
-   :sessions [empty-session [hot-rule cold-rule] {:max-cycles 3000}]}
+   :sessions [empty-session [hot-rule cold-rule] {}]}
 
-  (assert-ex-data  {:clara-rules/infinite-loop-suspected true}  (fire-rules empty-session)))
+  (assert-ex-data  {:clara-rules/infinite-loop-suspected true}  (fire-rules empty-session {:max-cycles 3000})))
 
 
 (def-rules-test test-recursive-insertion
@@ -25,17 +29,50 @@
   {:rules [cold-rule [[[Cold]]
                       (insert! (->Cold "ORD"))]]
 
-   ;; Use a small value here to ensure that we don't run out of memory before throwing.
-   ;; There is unfortunately a tradeoff where making the default number of cycles allowed
-   ;; high enough for some use cases will allow others to create OutOfMemory errors in cases
-   ;; like these but we can at least throw when there is enough memory available to hold the facts
-   ;; created in the loop.
-   :sessions [empty-session [cold-rule] {:max-cycles 10}]}
+   :sessions [empty-session [cold-rule] {}]}
 
   (assert-ex-data {:clara-rules/infinite-loop-suspected true}
                   (-> empty-session
                       (insert (->Cold "ARN"))
-                      fire-rules)))
+                      ;; Use a small value here to ensure that we don't run out of memory before throwing.
+                      ;; There is unfortunately a tradeoff where making the default number of cycles allowed
+                      ;; high enough for some use cases will allow others to create OutOfMemory errors in cases
+                      ;; like these but we can at least throw when there is enough memory available to hold the facts
+                      ;; created in the loop.
+                      (fire-rules {:max-cycles 10}))))
+
+(def-rules-test test-tracing-infinite-loop
+
+  {:rules [cold-rule [[[Cold]]
+                      (insert! (->Cold "ORD"))]]
+
+   :sessions [empty-session [cold-rule] {}]}
+
+  (try
+    (do (-> empty-session
+            tr/with-tracing
+            (insert (->Cold "ARN"))
+            ;; Use a small value here to ensure that we don't run out of memory before throwing.
+            ;; There is unfortunately a tradeoff where making the default number of cycles allowed
+            ;; high enough for some use cases will allow others to create OutOfMemory errors in cases
+            ;; like these but we can at least throw when there is enough memory available to hold the facts
+            ;; created in the loop.
+            (fire-rules {:max-cycles 10}))
+        (is false "The infinite loop did not throw an exception."))
+    (catch Exception e
+      (let [data-maps (ex-data-maps e)
+            loop-data (filter :clara-rules/infinite-loop-suspected data-maps)]
+        (is (= (count loop-data)
+               1)
+            "There should only be one exception in the chain from infinite rules loops.")
+        (is (= (-> loop-data first  :listeners count) 1)
+            "There should only be one listener.")
+        (is (-> loop-data first  :listeners ^PersistentTracingListener first .-trace not-empty)
+            "There should be tracing data available when a traced session throws an exception on an infinite loop.")))))
+            
+  
+
+
 
 
 

--- a/src/test/common/clara/test_testing_utils.cljc
+++ b/src/test/common/clara/test_testing_utils.cljc
@@ -1,7 +1,8 @@
 #?(:clj
    (ns clara.test-testing-utils
      (:require [clara.tools.testing-utils :refer [def-rules-test
-                                                  run-performance-test]]
+                                                  run-performance-test
+                                                  ex-data-maps]]
                [clara.rules :as r]
 
                [clara.rules.testfacts :refer [->Temperature ->Cold]]
@@ -71,3 +72,9 @@
                          :iterations 5
                          :mean-assertion (partial > 500)})
   (is (= @fire-rules-counter 5)))
+
+#?(:clj
+   (deftest test-ex-data-maps
+     (let [exception (ex-info  "Top" {:level :top} (IllegalArgumentException. "" (ex-info "Bottom" {:level :bottom})))]
+       (is  (= (ex-data-maps exception)
+               [{:level :top} {:level :bottom}])))))


### PR DESCRIPTION
…s not addressed yet.

This is still a fairly rough draft at this point.  Please don't merge it; I expect the durability tests to fail.  I wanted to give some visibility into my thinking here though.

Non-exhaustive lists of items for consideration:

-  The value of the :max-cycles setting is just a number, which means we could serialize it along with the session in durability.   Should we?  Pro:  it is one less thing for a user to think about upon deserialization.  Con: The Fressian implementation doesn't serialize other options that can't be reliably serialized.  Also this option doesn't impact the semantics of the ruleset, while other options do, so it arguably is different in kind.
- What should the default value be?