### PR TITLE
idempotent fact insertion proposal for discussion   (query -> conditional insert)

### DIFF
--- a/src/main/clojure/clara/idempotent.clj
+++ b/src/main/clojure/clara/idempotent.clj
@@ -1,0 +1,32 @@
+(ns clara.idempotent
+  "Implementation of insert-idempotent and defrecord-idempotent, such that duplicate identical facts will not be inserted."
+  (:require [clara.rules :refer [fire-rules insert]]))
+
+(defn dynamic-basis [record-class]
+  (clojure.lang.Reflector/invokeStaticMethod (.getName record-class) "getBasis" (into-array [])))
+
+(defprotocol ExactQueryable
+  (present? [fact session]))
+
+(defmacro prepare-idempotency [klass-sym]
+  (let [klass (resolve klass-sym)
+        fields (dynamic-basis klass)
+        constraints (into [] (map #(-> `(~'= ~(symbol (str "?" %)) ~%)))     fields) 
+        args        (into [] (comp (map #(str "?" (name %))) (map keyword))  fields)
+        query-sym   (symbol (str "exact-match-"(.getSimpleName klass)))
+        match-expr  (into [] cat (for [f fields] [(keyword (str "?" f)) (list (keyword f) 'fact)]))]
+    `(do
+       (defquery ~query-sym ~args [~'?f ~'<- ~klass-sym ~@constraints])
+       (extend-type ~klass-sym ExactQueryable
+                    (~'present? [~'fact ~'session]
+                     (-> ~'session (query ~query-sym ~@match-expr)
+                         first :?f))))))
+
+(defn insert-idempotent [session fact]
+  (if (present? fact session) session
+      (-> session (insert fact) fire-rules)))
+
+(defmacro defrecord-idempotent [& args]
+  `(do
+     (defrecord ~@args)
+     (prepare-idempotency ~(first args))))


### PR DESCRIPTION
an implementation of `idempotent-insert` related to #435

I'm not expecting this to be merged. It has no tests and doesn't support ClojureScript. This is more to start a discussion about the implementation. I do think this would be a useful feature for `clara.rules` to have, but I'm not sure that the implementation in this PR is the right approach.

Perhaps a "mode" for the session would be better. I understand that clara.rules is not storing every single fact necessarily, but that what is stored depends on the rules a fact might match.

The code here works (and I am going to use something like this for now), however:

* it's clojure only
* must call `fire-rules`
* it will only work with records, so that it can conveniently create
  an "exact match" query which matches on every field of the record
* doesn't include an `insert-idempotent!` for use in RHS