### PR TITLE
implementation of option to blacklist rules when creating sessions.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,3 +21,4 @@ Community
 [@sparkofreason]: https://github.com/sparkofreason
 [@bfontaine]: https://github.com/bfontaine
 [@sunilgunisetty]: https://github.com/sunilgunisetty
+[@bartuka]: https://github.com/wandersoncferreira

--- a/src/main/clojure/clara/rules.cljc
+++ b/src/main/clojure/clara/rules.cljc
@@ -338,6 +338,8 @@
         information might prove useful for debugging compilation errors within the rulebase, eg. rulebase serialization
         (ie. via Clara's durability support).
         Defaults to true, see clara.rules.compiler/omit-compile-ctx-default for more information.
+      * :blacklist, a vector of qualified namespace rules that will be blacklisted from the created session.
+        Defaults to [], all the rules provided will be considered.
 
       This is not supported in ClojureScript, since it requires eval to dynamically build a session. ClojureScript
       users must use pre-defined rule sessions using defsession."

--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -2036,6 +2036,14 @@
          (vary-meta production assoc ::rule-load-order (or n 0)))
        (range) productions))
 
+
+(defn remove-blacklisted-rules
+  "If an option :blacklist was provided by the user, we filter out the rules indicated."
+  [options rules]
+  (let [blacklist (set (map str (:blacklist options)))
+        not-contains? (complement contains?)]
+    (filter #(not-contains? blacklist (:name %)) rules)))
+
 (defn mk-session
   "Creates a new session using the given rule source. The resulting session
   is immutable, and can be used with insert, retract, fire-rules, and query functions."
@@ -2047,6 +2055,7 @@
                           (mapcat #(if (satisfies? IRuleSource %)
                                      (load-rules %)
                                      %))
+                          (remove-blacklisted-rules options)
                           add-production-load-order
                           ;; Ensure that we choose the earliest occurrence of a rule for the purpose of rule order.
                           ;; There are Clojure core functions for distinctness, of course, but none of them seem to guarantee

--- a/src/test/common/clara/test_blacklist.cljc
+++ b/src/test/common/clara/test_blacklist.cljc
@@ -1,0 +1,107 @@
+#?(:clj
+   (ns clara.test-blacklist
+     (:require [clara.tools.testing-utils :refer [def-rules-test] :as tu]
+               [clara.rules :refer [fire-rules
+                                    insert
+                                    insert!
+                                    query]]
+
+               [clara.rules.testfacts :refer [->Temperature
+                                              ->Cold
+                                              ->Hot
+                                              ->TemperatureHistory
+                                              ->ColdAndWindy]]
+               [clojure.test :refer [is]]
+               [clara.rules.accumulators])
+     (:import [clara.rules.testfacts
+               Temperature
+               Cold
+               Hot
+               ColdAndWindy
+               TemperatureHistory]))
+
+   :cljs
+   (ns clara.test-blacklist
+     (:require [clara.rules :refer [fire-rules
+                                    insert
+                                    insert!
+                                    query]]
+               [clara.rules.testfacts :refer [->Temperature Temperature
+                                              ->Cold Cold
+                                              ->Hot Hot
+                                              ->ColdAndWindy ColdAndWindy
+                                              ->TemperatureHistory TemperatureHistory]]
+               [clara.rules.accumulators]
+               [cljs.test])
+     (:require-macros [clara.tools.testing-utils :refer [def-rules-test]]
+                      [cljs.test :refer [is]])))
+
+(def-rules-test test-blacklist-a-rule
+  {:rules [cold-rule [[[Temperature (< temperature 20) (= ?t temperature)]]
+                      (insert! (->Cold ?t))]
+           history-rule [[[Temperature (< temperature 20) (= ?t temperature)]]
+                         (insert! (->TemperatureHistory [?t]))]]
+
+   :queries [cold-query [[] [[Cold (= ?c temperature)]]]
+             history-query [[] [[TemperatureHistory (= ?t temperatures)]]]]
+
+   :sessions [empty-session [cold-rule cold-query history-rule history-query] {:blacklist ['cold-rule]}]}
+
+  (let [session (-> empty-session
+                    (insert (->Temperature 10 "MCI"))
+                    (fire-rules))]
+
+    (is (empty? (query session cold-query))) ;removed rule
+
+    (is (= #{{:?t [10]}}
+           (set (query session history-query))))))
+
+(def-rules-test test-blacklist-many-rules
+  {:rules [cold-rule [[[Temperature (< temperature 20) (= ?t temperature)]]
+                      (insert! (->Cold ?t))]
+           history-rule [[[Temperature (< temperature 20) (= ?t temperature)]]
+                         (insert! (->TemperatureHistory [?t]))]
+           hot-rule [[[Temperature (> temperature 50) (= ?t temperature)]]
+                     (insert! (->Hot ?t))]
+           cold-and-windy-rule [[[Cold (> temperature 30) (= ?t temperature)]]
+                                (insert! (->ColdAndWindy ?t 60))]]
+
+   :queries [cold-query [[] [[Cold (= ?c temperature)]]]
+             history-query [[] [[TemperatureHistory (= ?ht temperatures)]]]
+             hot-query [[] [[Hot (= ?h temperature)]]]
+             cold-windy-query [[] [[ColdAndWindy (= ?cw temperature)]]]]
+
+   :sessions [empty-session [cold-rule cold-query
+                             history-rule history-query
+                             hot-rule hot-query
+                             cold-and-windy-rule cold-windy-query] {:blacklist ['history-rule
+                                                                                'hot-rule
+                                                                                'cold-and-windy-rule]}]}
+
+  (let [session (-> empty-session
+                    (insert (->Temperature 10 "MCI"))
+                    (insert (->Cold 40))
+                    (insert (->Temperature 70 "MCI"))
+                    (fire-rules))]
+
+    (is (empty? (query session history-query)))
+    (is (empty? (query session hot-query)))
+    (is (empty? (query session cold-windy-query)))
+
+    (is (= #{{:?c 10} {:?c 40}}
+           (set (query session cold-query))))))
+
+
+(def-rules-test test-blacklist-a-query
+  {:rules [cold-rule [[[Temperature (< temperature 20) (= ?t temperature)]]
+                      (insert! (->Cold ?t))]]
+
+   :queries [cold-query [[] [[Cold (= ?c temperature)]]]]
+
+   :sessions [empty-session [cold-rule cold-query] {:blacklist ['cold-query]}]}
+
+  (let [session (-> empty-session
+                    (insert (->Temperature 10 "MCI"))
+                    (fire-rules))]
+    (is (thrown? java.lang.IllegalArgumentException
+                 (query session cold-query)))))


### PR DESCRIPTION
The idea is to enable the users to blacklist a specific rule inside a namespace for example.

An example that motivated this implementation was because I have a namespace with many rules defined, however, for some clients I wish to "disable" some specific rules from being loaded into the session.

The workaround I have to do now is to load all the individual rules in the session, instead I wanted to load the entire namespace and only blacklist the ones I wish to remove.

Example of the implemented API:

```clojure
(defrecord Values [id])
  (defrule testing->include
    [?value <- Values [v] (= ?id (:id v))]
    =>
    (println "INCLUDING!!! " ?value))
  (defrule testing->exclude
    [?value <- Values [v] (= ?id (:id v))]
    =>
    (println "EXCLUDING!!! " ?value))
  (def session-without (rl/mk-session 'clara.rules.compiler/testing->include
                                      'clara.rules.compiler/testing->exclude
                                      :blacklist ['clara.rules.compiler/testing->exclude]))
```

This is a working implementation. I don't know all the internals of the library to antecipate more drawbacks that this feature could bring. All the tests are working fine.