### PR TITLE
warning the user at compile time about the unused bindings

### DIFF
--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -5,6 +5,7 @@
   (:require [clara.rules.engine :as eng]
             [clara.rules.listener :as listener]
             [clara.rules.platform :as platform]
+            [clara.rules.logger :as logger]
             [clara.rules.schema :as schema]
             [clojure.core.reducers :as r]
             [clojure.reflect :as reflect]
@@ -2059,6 +2060,8 @@
                                       (conj! previous new-production)))
                                   (transient #{}))
                           persistent!)]
+
+     (logger/warn-unused-bindings! productions)
 
      (if-let [session (get @session-cache [productions options])]
        session

--- a/src/main/clojure/clara/rules/logger.cljc
+++ b/src/main/clojure/clara/rules/logger.cljc
@@ -1,0 +1,25 @@
+(ns clara.rules.logger)
+
+(defn- warn-unused-binding
+  [{:keys [lhs rhs] :as production}]
+  (let [re-binding #"\?[\w-]+"
+        constraints-bindings (->> lhs
+                                  (mapcat :constraints)
+                                  (map (comp (partial re-find re-binding) str))
+                                  (filter some?))
+        fact-bindings (->> lhs
+                           (map :fact-binding)
+                           (filter some?)
+                           (map name))
+        rhs-bindings (re-seq re-binding (str rhs))]
+    (run! (fn [[?bind freq]]
+            (when (= freq 1)
+              (println (format "WARNING: binding %s defined at %s is not being used" ?bind (:name production)))))
+          (->> constraints-bindings
+               (concat fact-bindings rhs-bindings)
+               (filter some?)
+               frequencies))))
+
+(defn warn-unused-bindings!
+  [productions]
+  (run! warn-unused-binding productions))


### PR DESCRIPTION
A first solution to #444 , however there are some questions:

i) How would we handle switching it on/off? dynamic var? include a logging library and provide control through log levels?
ii) What will be the default behavior? I think it should be off. People may notice a difference in response time due to additional code that she does not sign up for.
iii) It need an explicit test or does the fact that it is running for all the tests in the suite already good enough?


I was curious to see how the clara-rules project itself would perform on this new flag. I uploaded it to a [webpaste service](http://ix.io/27BP/text) but I can paste it here if someone want it. It has 1k lines in total.