### PR TITLE
convert mk-session to a function since it does not need to be a macro

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,7 @@ Community
 - David Goeke [@dgoeke]
 - Dave Dixon [@sparkofreason]
 - Baptiste Fontaine [@bfontaine]
+- Jose Gomez [@k13gomez]
 
 [@rbrush]: https://github.com/rbrush
 [@mrrodriguez]: https://github.com/mrrodriguez

--- a/src/main/clojure/clara/rules.cljc
+++ b/src/main/clojure/clara/rules.cljc
@@ -308,7 +308,7 @@
                          [(deref %)])))))))
 
 #?(:clj
-  (defmacro mk-session
+  (defn mk-session
      "Creates a new session using the given rule sources. The resulting session
       is immutable, and can be used with insert, retract, fire-rules, and query functions.
 
@@ -346,8 +346,8 @@
       users must use pre-defined rule sessions using defsession."
      [& args]
      (if (and (seq args) (not (keyword? (first args))))
-       `(com/mk-session ~(vec args)) ; At least one namespace given, so use it.
-       `(com/mk-session (concat [(ns-name *ns*)] ~(vec args)))))) ; No namespace given, so use the current one.
+       (com/mk-session (vec args)) ; At least one namespace given, so use it.
+       (com/mk-session (cons (ns-name *ns*) (vec args)))))) ; No namespace given, so use the current one.
 
 #?(:clj
   (defmacro defsession


### PR DESCRIPTION
Having mk-session be a function makes it more easy to plug into several session building scenarios, including creating middleware for it to add custom caching or behavior.