### PR TITLE
Configure Travis CI build using stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,22 @@
+os: linux
+# see https://docs.travis-ci.com/user/reference/xenial/
+dist: xenial
 language: clojure
 lein: 2.7.1
-script:
-  - lein test
-  - lein test :generative
-  - lein with-profile dev,recent-clj test
-deploy:
-  provider: script
-  script: lein deploy clojars
-  on:
-    tags: true
-    all_branches: false
-    condition: $TRAVIS_TAG =~ ^(\d+)\.(\d+)\.(\d+)(-.+)?$
-# Workaround for https://github.com/travis-ci/travis-ci/issues/4691
-sudo: required
 jdk:
   - openjdk8
+# see https://docs.travis-ci.com/user/build-stages/
+stages:
+  - test
+  - deploy
+jobs:
+  include:
+    - stage: test
+      script:
+        - lein test
+        - lein test :generative
+        - lein with-profile dev,recent-clj test
+    - stage: deploy
+      script: lein deploy clojars
+      #see https://docs.travis-ci.com/user/conditions-v1
+      if: fork = false AND tag =~ ^(\d+)\.(\d+)\.(\d+)(-.+)?$


### PR DESCRIPTION
I refactored the travis build config to use jobs with stages, it now has two stages:
1. test (runs the test commands)
2. deploy (only runs if on a release tag)
I also fixed the invalid syntax I setup previously used for filtering tags, and verified this one worked through testing on a separate repo (trial and error until I found what worked correctly).

Fixes Issue #473 